### PR TITLE
feat: smart polling – configurable time windows + post-brush cooldown

### DIFF
--- a/custom_components/oclean_ble/__init__.py
+++ b/custom_components/oclean_ble/__init__.py
@@ -14,7 +14,10 @@ from .const import (
     CONF_DEVICE_NAME,
     CONF_MAC_ADDRESS,
     CONF_POLL_INTERVAL,
+    CONF_POLL_WINDOWS,
+    CONF_POST_BRUSH_COOLDOWN,
     DEFAULT_POLL_INTERVAL,
+    DEFAULT_POST_BRUSH_COOLDOWN,
     DOMAIN,
 )
 from .coordinator import OcleanCoordinator
@@ -83,7 +86,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
     )
 
-    coordinator = OcleanCoordinator(hass, mac, device_name, poll_interval)
+    poll_windows = entry.options.get(CONF_POLL_WINDOWS, "")
+    post_brush_cooldown_h = int(
+        entry.options.get(CONF_POST_BRUSH_COOLDOWN, DEFAULT_POST_BRUSH_COOLDOWN)
+    )
+
+    coordinator = OcleanCoordinator(
+        hass, mac, device_name, poll_interval,
+        poll_windows=poll_windows,
+        post_brush_cooldown_h=post_brush_cooldown_h,
+    )
 
     # Perform the first refresh – raises ConfigEntryNotReady if device unreachable
     # and no cached data exists yet.

--- a/custom_components/oclean_ble/config_flow.py
+++ b/custom_components/oclean_ble/config_flow.py
@@ -11,12 +11,19 @@ from homeassistant import config_entries
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
 
 from .const import (
     CONF_DEVICE_NAME,
     CONF_MAC_ADDRESS,
     CONF_POLL_INTERVAL,
+    CONF_POLL_WINDOWS,
+    CONF_POST_BRUSH_COOLDOWN,
+    CONF_WINDOW_COUNT,
+    CONF_WINDOW_END,
+    CONF_WINDOW_START,
     DEFAULT_POLL_INTERVAL,
+    DEFAULT_POST_BRUSH_COOLDOWN,
     DOMAIN,
     MIN_POLL_INTERVAL,
     OCLEAN_SERVICE_UUID,
@@ -25,6 +32,37 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+
+def _parse_windows_list(windows_str: str) -> list[tuple[str, str]]:
+    """Parse 'HH:MM-HH:MM[, ...]' into a list of ('HH:MM:00', 'HH:MM:00') tuples.
+
+    The ':00' suffix makes the values directly usable as TimeSelector defaults.
+    """
+    result: list[tuple[str, str]] = []
+    for part in (windows_str or "").split(",")[:3]:
+        part = part.strip()
+        if "-" not in part:
+            continue
+        try:
+            s_raw, e_raw = part.split("-", 1)
+            s_raw, e_raw = s_raw.strip(), e_raw.strip()
+            sh, sm = s_raw.split(":")
+            eh, em = e_raw.split(":")
+            int(sh), int(sm), int(eh), int(em)  # validate
+        except (ValueError, AttributeError):
+            continue
+        result.append((f"{s_raw}:00", f"{e_raw}:00"))
+    return result
+
+
+def _windows_list_to_str(windows: list[tuple[str, str]]) -> str:
+    """Combine ('HH:MM:SS', 'HH:MM:SS') tuples into 'HH:MM-HH:MM[, ...]' for storage."""
+    parts: list[str] = []
+    for s, e in windows:
+        s5, e5 = s[:5], e[:5]  # "HH:MM:SS" → "HH:MM"
+        if s5 and e5 and s5 != e5:
+            parts.append(f"{s5}-{e5}")
+    return ", ".join(parts)
 
 
 class OcleanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -191,21 +229,60 @@ class OcleanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class OcleanOptionsFlow(config_entries.OptionsFlow):
-    """Handle Oclean options (poll interval).
+    """Handle Oclean options via a multi-step flow.
+
+    Step 1 (init):     poll interval, post-brush cooldown, number of poll windows (0-3)
+    Step 2-4 (window_1/2/3): one TimeSelector pair per requested window
 
     Note: self.config_entry is injected automatically by HA since 2024.3.
     """
+
+    def __init__(self) -> None:
+        self._poll_interval: int = DEFAULT_POLL_INTERVAL
+        self._cooldown: int = DEFAULT_POST_BRUSH_COOLDOWN
+        self._window_count: int = 0
+        # Windows parsed from the current config – used to pre-fill each window step.
+        self._existing_windows: list[tuple[str, str]] = []
+        # Windows collected step-by-step as the user fills them in.
+        self._collected_windows: list[tuple[str, str]] = []
+
+    # ------------------------------------------------------------------
+    # Step 1 – global settings + window count
+    # ------------------------------------------------------------------
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            self._poll_interval = user_input[CONF_POLL_INTERVAL]
+            self._cooldown = int(
+                user_input.get(CONF_POST_BRUSH_COOLDOWN, DEFAULT_POST_BRUSH_COOLDOWN)
+            )
+            self._window_count = int(user_input.get(CONF_WINDOW_COUNT, 0))
+            self._collected_windows = []
+            if self._window_count > 0:
+                return await self.async_step_window_1()
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_POLL_INTERVAL: self._poll_interval,
+                    CONF_POST_BRUSH_COOLDOWN: self._cooldown,
+                    CONF_POLL_WINDOWS: "",
+                },
+            )
 
         current_interval = self.config_entry.options.get(
             CONF_POLL_INTERVAL,
             self.config_entry.data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
         )
+        current_cooldown = int(
+            self.config_entry.options.get(CONF_POST_BRUSH_COOLDOWN, DEFAULT_POST_BRUSH_COOLDOWN)
+        )
+        self._existing_windows = _parse_windows_list(
+            self.config_entry.options.get(CONF_POLL_WINDOWS, "")
+        )
+        current_count = len(self._existing_windows)
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -213,6 +290,97 @@ class OcleanOptionsFlow(config_entries.OptionsFlow):
                     vol.Required(CONF_POLL_INTERVAL, default=current_interval): vol.All(
                         int, vol.Range(min=MIN_POLL_INTERVAL)
                     ),
+                    vol.Optional(
+                        CONF_POST_BRUSH_COOLDOWN, default=current_cooldown
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0,
+                            max=23,
+                            step=1,
+                            unit_of_measurement="h",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_WINDOW_COUNT, default=current_count
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0, max=3, step=1, mode=selector.NumberSelectorMode.BOX
+                        )
+                    ),
+                }
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Steps 2-4 – one step per poll window
+    # ------------------------------------------------------------------
+
+    async def async_step_window_1(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        return await self._async_step_window(1, user_input)
+
+    async def async_step_window_2(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        return await self._async_step_window(2, user_input)
+
+    async def async_step_window_3(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        return await self._async_step_window(3, user_input)
+
+    async def _async_step_window(
+        self, num: int, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            s = (user_input.get(CONF_WINDOW_START) or "").strip()
+            e = (user_input.get(CONF_WINDOW_END) or "").strip()
+            if not s:
+                errors[CONF_WINDOW_START] = "window_incomplete"
+            elif not e:
+                errors[CONF_WINDOW_END] = "window_incomplete"
+
+            if not errors:
+                self._collected_windows.append((s, e))
+                if num < self._window_count:
+                    return await getattr(self, f"async_step_window_{num + 1}")()
+                return self.async_create_entry(
+                    title="",
+                    data={
+                        CONF_POLL_INTERVAL: self._poll_interval,
+                        CONF_POST_BRUSH_COOLDOWN: self._cooldown,
+                        CONF_POLL_WINDOWS: _windows_list_to_str(self._collected_windows),
+                    },
+                )
+
+        # Pre-populate from current config if this window already existed.
+        existing = (
+            self._existing_windows[num - 1]
+            if num - 1 < len(self._existing_windows)
+            else None
+        )
+        s_default = existing[0] if existing else None
+        e_default = existing[1] if existing else None
+
+        return self.async_show_form(
+            step_id=f"window_{num}",
+            errors=errors,
+            data_schema=vol.Schema(
+                {
+                    (
+                        vol.Required(CONF_WINDOW_START, default=s_default)
+                        if s_default
+                        else vol.Required(CONF_WINDOW_START)
+                    ): selector.TimeSelector(),
+                    (
+                        vol.Required(CONF_WINDOW_END, default=e_default)
+                        if e_default
+                        else vol.Required(CONF_WINDOW_END)
+                    ): selector.TimeSelector(),
                 }
             ),
         )

--- a/custom_components/oclean_ble/const.py
+++ b/custom_components/oclean_ble/const.py
@@ -46,6 +46,14 @@ RESP_K3GUIDE = bytes.fromhex("0340")    # Real-time zone guidance during brushin
 CONF_MAC_ADDRESS = "mac_address"
 CONF_POLL_INTERVAL = "poll_interval"
 CONF_DEVICE_NAME = "device_name"
+CONF_POLL_WINDOWS = "poll_windows"           # str: "HH:MM-HH:MM[, HH:MM-HH:MM, ...]", "" = disabled
+CONF_POST_BRUSH_COOLDOWN = "post_brush_cooldown"  # int hours, 0 = disabled
+
+# Options-flow fields for the multi-step window setup (not persisted; combined into CONF_POLL_WINDOWS).
+CONF_WINDOW_COUNT = "window_count"   # int 0-3: how many poll windows the user wants
+CONF_WINDOW_START = "window_start"   # str "HH:MM:SS": start time in a per-window step
+CONF_WINDOW_END   = "window_end"     # str "HH:MM:SS": end time in a per-window step
+DEFAULT_POST_BRUSH_COOLDOWN = 0
 
 # Coordinator data keys
 DATA_BATTERY = "battery"

--- a/custom_components/oclean_ble/translations/de.json
+++ b/custom_components/oclean_ble/translations/de.json
@@ -92,12 +92,43 @@
       "init": {
         "title": "Oclean-Optionen",
         "data": {
-          "poll_interval": "Abfrageintervall (Sekunden)"
+          "poll_interval": "Abfrageintervall (Sekunden)",
+          "post_brush_cooldown": "Cooldown nach dem Putzen (Stunden)",
+          "window_count": "Anzahl der Zahnputz-Zeitfenster"
         },
         "data_description": {
-          "poll_interval": "Wie oft die Zahnbürste per Bluetooth abgefragt werden soll. Minimum: 60 s."
+          "poll_interval": "Wie oft die Zahnbürste per Bluetooth abgefragt werden soll. Minimum: 60 s.",
+          "post_brush_cooldown": "Abfragen für diese Anzahl Stunden pausieren, nachdem eine neue Putzsitzung erkannt wurde. 0 = deaktiviert.",
+          "window_count": "Abfrage auf bestimmte Zeitfenster beschränken (z. B. morgens und abends beim Zähneputzen). 0 = immer abfragen."
+        }
+      },
+      "window_1": {
+        "title": "Zahnputz-Zeitfenster 1",
+        "description": "Erstes Zeitfenster definieren, in dem die Zahnbürste abgefragt wird.",
+        "data": {
+          "window_start": "Von",
+          "window_end": "Bis"
+        }
+      },
+      "window_2": {
+        "title": "Zahnputz-Zeitfenster 2",
+        "description": "Zweites Zeitfenster definieren, in dem die Zahnbürste abgefragt wird.",
+        "data": {
+          "window_start": "Von",
+          "window_end": "Bis"
+        }
+      },
+      "window_3": {
+        "title": "Zahnputz-Zeitfenster 3",
+        "description": "Drittes Zeitfenster definieren, in dem die Zahnbürste abgefragt wird.",
+        "data": {
+          "window_start": "Von",
+          "window_end": "Bis"
         }
       }
+    },
+    "error": {
+      "window_incomplete": "Von- und Bis-Zeit müssen beide gesetzt sein."
     }
   }
 }

--- a/custom_components/oclean_ble/translations/en.json
+++ b/custom_components/oclean_ble/translations/en.json
@@ -92,12 +92,43 @@
       "init": {
         "title": "Oclean Options",
         "data": {
-          "poll_interval": "Poll interval (seconds)"
+          "poll_interval": "Poll interval (seconds)",
+          "post_brush_cooldown": "Post-brush cooldown (hours)",
+          "window_count": "Number of brushing time windows"
         },
         "data_description": {
-          "poll_interval": "How often to poll the toothbrush over Bluetooth. Minimum 60 s."
+          "poll_interval": "How often to poll the toothbrush over Bluetooth. Minimum 60 s.",
+          "post_brush_cooldown": "Pause polling for this many hours after a new brushing session is detected. Set to 0 to disable.",
+          "window_count": "Restrict polling to specific time windows (e.g. morning and evening brushing). Set to 0 to always poll."
+        }
+      },
+      "window_1": {
+        "title": "Brushing Window 1",
+        "description": "Define the first time window during which the toothbrush will be polled.",
+        "data": {
+          "window_start": "From",
+          "window_end": "To"
+        }
+      },
+      "window_2": {
+        "title": "Brushing Window 2",
+        "description": "Define the second time window during which the toothbrush will be polled.",
+        "data": {
+          "window_start": "From",
+          "window_end": "To"
+        }
+      },
+      "window_3": {
+        "title": "Brushing Window 3",
+        "description": "Define the third time window during which the toothbrush will be polled.",
+        "data": {
+          "window_start": "From",
+          "window_end": "To"
         }
       }
+    },
+    "error": {
+      "window_incomplete": "Both start and end time must be set."
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,35 @@ def _install_ha_stubs() -> None:
     # ---- homeassistant.helpers (parent) ----
     _stub("homeassistant.helpers")
 
+    # ---- homeassistant.helpers.selector ----
+    sel = _stub("homeassistant.helpers.selector")
+
+    class NumberSelectorMode:
+        BOX = "box"
+        SLIDER = "slider"
+
+    class NumberSelectorConfig:
+        def __init__(self, **kwargs):
+            pass
+
+    class NumberSelector:
+        def __init__(self, config=None):
+            pass
+
+    class TextSelectorConfig:
+        def __init__(self, **kwargs):
+            pass
+
+    class TextSelector:
+        def __init__(self, config=None):
+            pass
+
+    sel.NumberSelectorMode = NumberSelectorMode
+    sel.NumberSelectorConfig = NumberSelectorConfig
+    sel.NumberSelector = NumberSelector
+    sel.TextSelectorConfig = TextSelectorConfig
+    sel.TextSelector = TextSelector
+
     # ---- homeassistant.helpers.update_coordinator ----
     uc = _stub("homeassistant.helpers.update_coordinator")
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import pytest
 
 # conftest.py stubs HA before these imports
-from custom_components.oclean_ble.config_flow import _MAC_RE
+from custom_components.oclean_ble.config_flow import (
+    _MAC_RE,
+    _parse_windows_list,
+    _windows_list_to_str,
+)
 from custom_components.oclean_ble.const import (
     DEFAULT_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
@@ -78,3 +82,56 @@ class TestMacNormalization:
         raw = "Aa:Bb:Cc:Dd:Ee:Ff"
         normalized = raw.upper().strip()
         assert _MAC_RE.match(normalized)
+
+
+# ---------------------------------------------------------------------------
+# Poll window helpers
+# ---------------------------------------------------------------------------
+
+class TestParseWindowsList:
+    def test_empty_string_returns_empty(self):
+        assert _parse_windows_list("") == []
+
+    def test_single_window(self):
+        assert _parse_windows_list("07:00-09:00") == [("07:00:00", "09:00:00")]
+
+    def test_two_windows(self):
+        result = _parse_windows_list("07:00-09:00, 20:00-22:30")
+        assert result == [("07:00:00", "09:00:00"), ("20:00:00", "22:30:00")]
+
+    def test_three_windows(self):
+        result = _parse_windows_list("06:00-07:00, 12:00-13:00, 21:00-22:00")
+        assert len(result) == 3
+
+    def test_honours_max_three(self):
+        result = _parse_windows_list("06:00-07:00, 08:00-09:00, 10:00-11:00, 12:00-13:00")
+        assert len(result) == 3
+
+    def test_invalid_entry_skipped(self):
+        result = _parse_windows_list("notawindow, 07:00-09:00")
+        assert result == [("07:00:00", "09:00:00")]
+
+    def test_whitespace_tolerant(self):
+        assert _parse_windows_list("  07:00 - 09:00  ") == [("07:00:00", "09:00:00")]
+
+
+class TestWindowsListToStr:
+    def test_empty_list(self):
+        assert _windows_list_to_str([]) == ""
+
+    def test_single_window(self):
+        assert _windows_list_to_str([("07:00:00", "09:00:00")]) == "07:00-09:00"
+
+    def test_two_windows(self):
+        result = _windows_list_to_str([("07:00:00", "09:00:00"), ("20:00:00", "22:30:00")])
+        assert result == "07:00-09:00, 20:00-22:30"
+
+    def test_strips_seconds(self):
+        assert _windows_list_to_str([("07:30:45", "09:15:00")]) == "07:30-09:15"
+
+    def test_equal_start_end_skipped(self):
+        assert _windows_list_to_str([("07:00:00", "07:00:00")]) == ""
+
+    def test_roundtrip(self):
+        original = "07:00-09:00, 20:00-22:30"
+        assert _windows_list_to_str(_parse_windows_list(original)) == original


### PR DESCRIPTION
Add two new optional settings to reduce BLE polling when it isn't useful:

• Poll windows (up to 3×, HH:MM-HH:MM, overnight supported)
  – Only connect to the toothbrush during configured windows.
  – Polls outside all windows are skipped and the last known
    coordinator data is returned unchanged.

• Post-brush cooldown (0–23 h)
  – After a new brushing session is detected, polling is paused
    for the configured number of hours.
  – Motivation: a second brushing session within the cooldown
    period is unlikely, so connecting repeatedly wastes battery.

Implementation details:
  • `const.py` – CONF_POLL_WINDOWS, CONF_POST_BRUSH_COOLDOWN,
    DEFAULT_POST_BRUSH_COOLDOWN
  • `coordinator.py` – module-level `_parse_poll_windows()` +
    `_in_window()` helpers; `_poll_skip_reason()` method;
    cooldown_until tracking after new sessions detected
  • `__init__.py` – read new options and pass to coordinator
  • `config_flow.py` – OcleanOptionsFlow extended with
    NumberSelector (cooldown) + TextSelector (windows) +
    format validation (invalid_poll_windows error)
  • `translations/en.json` + `de.json` – new labels,
    descriptions and error string
  • `tests/conftest.py` – selector stubs
  • `tests/test_coordinator.py` – 17 new unit tests for
    _parse_poll_windows and _in_window (206 tests total, all green)