### PR TITLE
feat: add enrichment wait to capture 0000/2604 score notifications

### DIFF
--- a/custom_components/oclean_ble/const.py
+++ b/custom_components/oclean_ble/const.py
@@ -80,6 +80,10 @@ DATA_LAST_BRUSH_TIME = "last_brush_time"
 BLE_CONNECT_TIMEOUT = 10
 # Time to wait for notifications after sending a command
 BLE_NOTIFICATION_WAIT = 3
+# Extra wait after receiving a session, allowing the device time to push
+# enrichment notifications (0000 score, 2604 zone pressures).  These are
+# unsolicited pushes the device sends shortly after the 0307 session response.
+BLE_ENRICHMENT_WAIT = 1.5
 
 # Brush head reset command
 CMD_CLEAR_BRUSH_HEAD = bytes.fromhex("020F")

--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     BATTERY_CHAR_UUID,
+    BLE_ENRICHMENT_WAIT,
     BLE_NOTIFICATION_WAIT,
     CMD_CALIBRATE_TIME_PREFIX,
     CMD_CLEAR_BRUSH_HEAD,
@@ -492,6 +493,12 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         if READ_NOTIFY_CHAR_UUID not in subscribed:
             await self._read_response_char_fallback(client, notification_handler)
         await self._paginate_sessions(client, all_sessions, session_received)
+        if all_sessions:
+            # Allow the device extra time to push enrichment notifications
+            # (0000 score, 2604 zone pressures) that arrive unsolicited after
+            # the session response.  Without this wait the BLE session ends
+            # before those pushes are received.
+            await asyncio.sleep(BLE_ENRICHMENT_WAIT)
         await self._read_battery_and_unsubscribe(client, collected)
 
         # Enrich the latest session snapshot with fields from enrichment notifications


### PR DESCRIPTION
After receiving session data the device pushes unsolicited 0000 (score) and 2604 (zone pressures) notifications.  Without a brief wait the BLE session was torn down before those enrichment pushes arrived, leaving last_brush_score always empty for inline single-session responses.

- Add BLE_ENRICHMENT_WAIT = 1.5 s constant (const.py)
- Sleep BLE_ENRICHMENT_WAIT after _paginate_sessions when sessions were received, giving the device time to push 0000/2604 before disconnect