### PR TITLE
fix: silence spurious 'could not parse' log for 0308 status acks (#26)

### DIFF
--- a/custom_components/oclean_ble/parser.py
+++ b/custom_components/oclean_ble/parser.py
@@ -194,6 +194,14 @@ def _parse_info_response(payload: bytes) -> dict[str, Any]:
         _LOGGER.debug("Oclean INFO: extended format detected but parsing failed, raw: %s", payload.hex())
         return {}
 
+    if len(payload) >= 2 and payload[0] == 0:
+        # Byte 0 == 0 marks the extended-format header but payload[1] < 32 means
+        # the device sent a short status/ack packet (no session record embedded).
+        # Cannot be interpreted as simple format (simple format has year ≥ 24 at
+        # byte 0).  Return silently – not an error.
+        _LOGGER.debug("Oclean INFO: short status packet (%d bytes), no session data", len(payload))
+        return {}
+
     # Simple 18-byte format
     record = _parse_running_data_record(payload)
     if record:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -235,6 +235,13 @@ class TestParseNotificationRouting:
         result = parse_notification(data)
         assert result == {}
 
+    def test_info_response_short_status_packet(self):
+        # 0308 with payload[0]==0, payload[1]==12 < 32 – "no-session" ack from
+        # OCLEANY3MH device (observed in issue #19 logs).  Should return {} silently.
+        data = bytes.fromhex("0308000c021c173bc7f97dd34f4b")
+        result = parse_notification(data)
+        assert result == {}
+
     def test_device_info_ack_routed(self):
         # 02 02 4F 4B → device-info ACK ("OK"), no sensor data
         data = bytes([0x02, 0x02, 0x4F, 0x4B])


### PR DESCRIPTION
Devices like OCLEANY3MH send a short 12-byte payload (000c…) after a status query as a "no sessions queued" ack.  The previous code reached the extended-record parser (payload[0]==0 but payload[1]<32) and logged a WARNING-level "could not parse" entry on every poll even though no error occurred.

Fix: detect the short status ack pattern (payload[0]==0 AND payload[1]<32) before the extended-record parser and return {} with a DEBUG log.

Closes #26