### PR TITLE
fix: update UI immediately after brush-head counter reset

### DIFF
--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import datetime
 import logging
 import struct
@@ -289,6 +290,8 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         self._brush_head_sw_count = 0
         await self._save_store()
         _LOGGER.debug("Oclean brush head sw counter reset to 0")
+        if self.data is not None:
+            self.async_set_updated_data(dataclasses.replace(self.data, brush_head_usage=0))
 
     # ------------------------------------------------------------------
     # Internal helpers


### PR DESCRIPTION
## Summary

After calling the **Reset Brush Head** button, the `brush_head_usage` sensor previously kept displaying the old value until the next scheduled BLE poll (up to 300 s later).

This fix calls `async_set_updated_data()` right after writing the reset to persistent storage, so all HA listeners (sensor entities, UI) update immediately.

## Changes

- `coordinator.py` – `reset_brush_head_counter()`: replace the in-memory `OcleanDeviceData` snapshot with `brush_head_usage=0` via `dataclasses.replace()` and propagate via `async_set_updated_data()`

## References

- Related: https://github.com/deniskie/ha-oclean-integration/issues/7