### PR TITLE
fix: update coordinator data immediately after brush-head counter reset

### DIFF
--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import datetime
 import logging
 import struct
@@ -289,6 +290,8 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         self._brush_head_sw_count = 0
         await self._save_store()
         _LOGGER.debug("Oclean brush head sw counter reset to 0")
+        if self.data is not None:
+            self.async_set_updated_data(dataclasses.replace(self.data, brush_head_usage=0))
 
     # ------------------------------------------------------------------
     # Internal helpers


### PR DESCRIPTION
Without this the UI kept showing the old brush_head_usage value until the next scheduled poll. async_set_updated_data() propagates the reset to all listeners right away.