### PR TITLE
feat: add manual poll mode and oclean_ble.poll action (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ After restart, go to **Settings → Integrations → Add Integration** and searc
 | Entity | Description | Status |
 |--------|-------------|--------|
 | `button.oclean_reset_brush_head` | Resets the brush head wear counter | ⚠️ Unconfirmed |
+| `button.oclean_sync_time` | Syncs the current time to the device clock | ✅ Tested |
 
 **Legend:**
 - ✅ **Tested** – confirmed working on real hardware with multiple sessions
@@ -89,8 +90,8 @@ After restart, go to **Settings → Integrations → Add Integration** and searc
 | Last brush timestamp | Device local time, confirmed across multiple sessions |
 | Last brush duration | Session length in seconds; confirmed on Oclean X (0307 format, APK-verified via AbstractC0002b.m18f) |
 | Last brush scheme type | Brush programme name/ID (pNum); confirmed on Oclean X via 0307 (APK-verified) |
-| Time calibration | Device clock synced on every poll |
-| Poll interval | Configurable 60–N seconds (default: 300 s) |
+| Time calibration | Device clock synced on every poll and on demand via the *Sync Time* button |
+| Poll interval | Configurable 60–86400 seconds (default: 300 s), or set to `0` for manual-only mode |
 | Stale data persistence | Sensors keep last known value when device is unreachable |
 | Config flow | Manual MAC address entry with validation |
 | Duplicate prevention | Sessions deduplicated by timestamp; no double-import |
@@ -122,6 +123,40 @@ After restart, go to **Settings → Integrations → Add Integration** and searc
 ## Configuration
 
 The poll interval and other options can be changed after setup via **Settings → Integrations → Oclean → Configure**.
+
+### Manual Polling Mode
+
+Set the poll interval to `0` in **Settings → Integrations → Oclean → Configure** to disable automatic polling entirely. In this mode the device is only contacted when you explicitly trigger a poll.
+
+Use the built-in `oclean_ble.poll` action to trigger a poll on demand – from automations, scripts, or the HA Developer Tools:
+
+```yaml
+action: oclean_ble.poll
+data: {}             # polls all Oclean devices
+```
+
+To target a single device when you have multiple brushes, pass its `entry_id` (found under **Settings → Integrations → Oclean → ⋮ → System Information**):
+
+```yaml
+action: oclean_ble.poll
+data:
+  entry_id: "abc123def456..."
+```
+
+This is useful for event-driven automations, for example polling immediately after a bed-occupancy sensor detects you went to sleep:
+
+```yaml
+automation:
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.bed_occupancy
+      to: "on"
+  action:
+    - action: oclean_ble.poll
+      data: {}
+```
+
+The `oclean_ble.poll` action is also available when automatic polling is active – it simply triggers an immediate poll in addition to the regular schedule.
 
 ### Post-Brush Cooldown
 
@@ -178,6 +213,7 @@ Unknown notification types are logged as hex – this helps extend the parser.
 - [ ] Confirm brush area / pressure / scheme fields on Oclean X Pro (OCLEANY3) and X Pro Elite (OCLEANY3P)
 - [ ] Validate real-time zone guidance on K3-series devices
 - [x] Configurable poll windows with native time picker
+- [x] Manual polling mode with `oclean_ble.poll` action
 - [ ] Publish to HACS default repository
 - [ ] Decode remaining unknown fields in session data
 

--- a/custom_components/oclean_ble/__init__.py
+++ b/custom_components/oclean_ble/__init__.py
@@ -6,9 +6,10 @@ import logging
 import logging.handlers
 import pathlib
 
+import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
@@ -20,6 +21,7 @@ from .const import (
     DEFAULT_POLL_INTERVAL,
     DEFAULT_POST_BRUSH_COOLDOWN,
     DOMAIN,
+    SERVICE_POLL,
 )
 from .coordinator import OcleanCoordinator
 
@@ -129,6 +131,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Listen for option updates (e.g. changed poll interval)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
+    # Register the poll service once per domain (shared across all config entries)
+    if not hass.services.has_service(DOMAIN, SERVICE_POLL):
+
+        async def _handle_poll(call: ServiceCall) -> None:
+            """Trigger an immediate BLE poll for one or all Oclean devices."""
+            entry_id: str | None = call.data.get("entry_id")
+            domain_data = hass.data.get(DOMAIN, {})
+            if entry_id:
+                coordinator = domain_data.get(entry_id)
+                if coordinator and isinstance(coordinator, OcleanCoordinator):
+                    await coordinator.async_request_refresh()
+            else:
+                for key, value in domain_data.items():
+                    if not key.startswith("_") and isinstance(value, OcleanCoordinator):
+                        await value.async_request_refresh()
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_POLL,
+            _handle_poll,
+            schema=vol.Schema({vol.Optional("entry_id"): str}),
+        )
+
     return True
 
 
@@ -137,10 +162,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
-        # Remove file handler only when no more entries remain
+        # Remove file handler and poll service only when no more entries remain
         remaining = [k for k in hass.data.get(DOMAIN, {}) if not k.startswith("_")]
         if not remaining:
             await _detach_file_handler(hass)
+            hass.services.async_remove(DOMAIN, SERVICE_POLL)
     return unload_ok
 
 

--- a/custom_components/oclean_ble/config_flow.py
+++ b/custom_components/oclean_ble/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     MIN_POLL_INTERVAL,
     OCLEAN_SERVICE_UUID,
+    POLL_INTERVAL_MANUAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -238,7 +239,7 @@ class OcleanOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is not None:
-            self._poll_interval = user_input[CONF_POLL_INTERVAL]
+            self._poll_interval = int(user_input[CONF_POLL_INTERVAL])
             self._cooldown = int(user_input.get(CONF_POST_BRUSH_COOLDOWN, DEFAULT_POST_BRUSH_COOLDOWN))
             self._window_count = int(user_input.get(CONF_WINDOW_COUNT, 0))
             self._collected_windows = []
@@ -265,8 +266,14 @@ class OcleanOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_POLL_INTERVAL, default=current_interval): vol.All(
-                        int, vol.Range(min=MIN_POLL_INTERVAL)
+                    vol.Required(CONF_POLL_INTERVAL, default=current_interval): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=POLL_INTERVAL_MANUAL,
+                            max=86400,
+                            step=1,
+                            unit_of_measurement="s",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
                     ),
                     vol.Optional(CONF_POST_BRUSH_COOLDOWN, default=current_cooldown): selector.NumberSelector(
                         selector.NumberSelectorConfig(

--- a/custom_components/oclean_ble/const.py
+++ b/custom_components/oclean_ble/const.py
@@ -6,6 +6,10 @@ MANUFACTURER = "Oclean"
 # Default polling interval in seconds
 DEFAULT_POLL_INTERVAL = 300  # 5 minutes
 MIN_POLL_INTERVAL = 60  # 1 minute
+POLL_INTERVAL_MANUAL = 0  # sentinel: disable automatic polling; only poll on-demand
+
+# Service names
+SERVICE_POLL = "poll"
 
 # BLE UUIDs
 OCLEAN_SERVICE_UUID = "8082caa8-41a6-4021-91c6-56f9b954cc18"

--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -180,7 +180,7 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=update_interval),
+            update_interval=timedelta(seconds=update_interval) if update_interval > 0 else None,
         )
         self._mac = mac_address
         self._device_name = device_name

--- a/custom_components/oclean_ble/services.yaml
+++ b/custom_components/oclean_ble/services.yaml
@@ -1,0 +1,14 @@
+poll:
+  name: Poll device
+  description: >
+    Trigger an immediate BLE poll for one or all Oclean devices.
+    Useful for manual polling mode or event-driven automations.
+  fields:
+    entry_id:
+      name: Config Entry ID
+      description: >
+        Optional. The config entry ID of the device to poll.
+        If omitted, all configured Oclean devices are polled.
+      required: false
+      selector:
+        text:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 These tests run WITHOUT a full Home Assistant instance.
 A minimal stub of every homeassistant.* module is injected before imports.
 """
+
 from __future__ import annotations
 
 import sys
@@ -21,6 +22,7 @@ sys.path.insert(0, str(_ROOT))
 # Module stub helper – idempotent (returns existing module if already created)
 # ---------------------------------------------------------------------------
 
+
 def _stub(name: str) -> ModuleType:
     """Return the stub module for *name*, creating it if necessary."""
     if name not in sys.modules:
@@ -38,21 +40,25 @@ def _install_ha_stubs() -> None:
     # ---- homeassistant.core ----
     core = _stub("homeassistant.core")
     core.HomeAssistant = MagicMock
+    core.ServiceCall = MagicMock
     core.callback = lambda f: f
 
     # ---- homeassistant.const ----
     from enum import Enum, StrEnum
+
     const = _stub("homeassistant.const")
     const.Platform = Enum("Platform", ["SENSOR", "BINARY_SENSOR", "BUTTON"])
     const.PERCENTAGE = "%"
 
     class UnitOfTime:
         SECONDS = "s"
+
     const.UnitOfTime = UnitOfTime
 
     class EntityCategory(StrEnum):
         DIAGNOSTIC = "diagnostic"
         CONFIG = "config"
+
     const.EntityCategory = EntityCategory
 
     # ---- homeassistant.exceptions ----
@@ -138,6 +144,7 @@ def _install_ha_stubs() -> None:
             self.hass = hass
             self.data = None
             self.last_update_success = True
+            self.update_interval = update_interval
 
         async def async_config_entry_first_refresh(self):
             self.data = await self._async_update_data()
@@ -162,10 +169,13 @@ def _install_ha_stubs() -> None:
 
     class _StoreStub:
         """Minimal async-compatible Store stub (avoids Python 3.14 InvalidSpecError)."""
+
         def __init__(self, *args, **kwargs):
             pass
+
         async def async_load(self):
             return None
+
         async def async_save(self, data):
             pass
 
@@ -210,8 +220,17 @@ def _install_ha_stubs() -> None:
         MEASUREMENT = "measurement"
 
     class SensorEntityDescription:
-        def __init__(self, *, key, name="", device_class=None, state_class=None,
-                     native_unit_of_measurement=None, icon=None, **kwargs):
+        def __init__(
+            self,
+            *,
+            key,
+            name="",
+            device_class=None,
+            state_class=None,
+            native_unit_of_measurement=None,
+            icon=None,
+            **kwargs,
+        ):
             self.key = key
             self.name = name
             self.device_class = device_class

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1414,7 +1414,6 @@ class TestAsyncSyncTime:
         client.disconnect.assert_awaited_once()
 
 
-# ---------------------------------------------------------------------------
 # Software brush-head counter increment
 # ---------------------------------------------------------------------------
 
@@ -1566,3 +1565,43 @@ class TestReadDeviceInfoServiceCacheExpiry:
         before = time.time()
         await coord._read_device_info_service(client, {})
         assert coord._dis_last_read_ts >= before
+
+
+# ---------------------------------------------------------------------------
+# Manual poll mode (poll_interval=0 → update_interval=None)
+# ---------------------------------------------------------------------------
+
+
+class TestManualPollMode:
+    def test_update_interval_is_none_when_poll_interval_zero(self):
+        """Coordinator must not set a timer when poll_interval=0 (manual mode)."""
+        coord = _make_coordinator(poll_interval=0)
+        assert coord.update_interval is None
+
+    def test_update_interval_set_when_poll_interval_nonzero(self):
+        """Coordinator must set a timer for positive poll_interval values."""
+        from datetime import timedelta
+
+        coord = _make_coordinator(poll_interval=300)
+        assert coord.update_interval == timedelta(seconds=300)
+
+    @pytest.mark.asyncio
+    async def test_async_request_refresh_triggers_poll_in_manual_mode(self):
+        """async_request_refresh() must poll the device even in manual mode."""
+        coord = _make_coordinator(poll_interval=0)
+        coord._store_loaded = True
+        client = _make_bleak_client()
+
+        with (
+            patch("custom_components.oclean_ble.coordinator.bluetooth") as bt_mock,
+            patch(
+                "custom_components.oclean_ble.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=client,
+            ),
+            patch("custom_components.oclean_ble.coordinator.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            bt_mock.async_last_service_info.return_value = _make_service_info()
+            result = await coord._poll_device()
+
+        assert result is not None


### PR DESCRIPTION
- Add POLL_INTERVAL_MANUAL=0 sentinel: setting the poll interval to 0 disables the automatic BLE timer (update_interval=None)
- Register oclean_ble.poll service on first setup; deregister when the last entry is unloaded. Accepts optional entry_id to target a single device; without it all Oclean coordinators are refreshed
- Options flow now uses a NumberSelector (min=0) so manual mode is selectable via the UI alongside the existing interval/window settings
- Add services.yaml for the oclean_ble.poll action description
- Document manual polling mode and example automation in README