### PR TITLE
fix: allow poll interval 0 (manual) in setup wizard

### DIFF
--- a/custom_components/oclean_ble/config_flow.py
+++ b/custom_components/oclean_ble/config_flow.py
@@ -57,6 +57,13 @@ def _parse_windows_list(windows_str: str) -> list[tuple[str, str]]:
     return result
 
 
+def _validate_poll_interval(value: int) -> int:
+    """Accept 0 (manual / no auto-polling) or any value >= MIN_POLL_INTERVAL."""
+    if value == POLL_INTERVAL_MANUAL or value >= MIN_POLL_INTERVAL:
+        return value
+    raise vol.Invalid(f"Poll interval must be 0 (manual) or at least {MIN_POLL_INTERVAL} seconds")
+
+
 def _windows_list_to_str(windows: list[tuple[str, str]]) -> str:
     """Combine ('HH:MM:SS', 'HH:MM:SS') tuples into 'HH:MM-HH:MM[, ...]' for storage."""
     parts: list[str] = []
@@ -111,7 +118,7 @@ class OcleanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
             data_schema=vol.Schema(
                 {
                     vol.Optional(CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL): vol.All(
-                        int, vol.Range(min=MIN_POLL_INTERVAL)
+                        int, _validate_poll_interval
                     ),
                 }
             ),
@@ -163,7 +170,7 @@ class OcleanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
                 {
                     vol.Required(CONF_MAC_ADDRESS): vol.In(device_options),
                     vol.Optional(CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL): vol.All(
-                        int, vol.Range(min=MIN_POLL_INTERVAL)
+                        int, _validate_poll_interval
                     ),
                 }
             ),
@@ -198,7 +205,7 @@ class OcleanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
                     vol.Required(CONF_MAC_ADDRESS): str,
                     vol.Optional(CONF_DEVICE_NAME, default="Oclean"): str,
                     vol.Optional(CONF_POLL_INTERVAL, default=DEFAULT_POLL_INTERVAL): vol.All(
-                        int, vol.Range(min=MIN_POLL_INTERVAL)
+                        int, _validate_poll_interval
                     ),
                 }
             ),

--- a/custom_components/oclean_ble/translations/de.json
+++ b/custom_components/oclean_ble/translations/de.json
@@ -23,7 +23,7 @@
         },
         "data_description": {
           "mac_address": "Die Bluetooth-MAC-Adresse deiner Oclean-Zahnbürste.",
-          "poll_interval": "Wie oft (in Sekunden) das Gerät abgefragt werden soll. Minimum: 60 s. Standard: 300 s (5 min)."
+          "poll_interval": "Wie oft (in Sekunden) das Gerät abgefragt werden soll. Minimum: 60 s, oder 0 zum Deaktivieren des automatischen Pollings. Standard: 300 s (5 min)."
         }
       },
       "confirm": {

--- a/custom_components/oclean_ble/translations/en.json
+++ b/custom_components/oclean_ble/translations/en.json
@@ -23,7 +23,7 @@
         },
         "data_description": {
           "mac_address": "The Bluetooth MAC address of your Oclean toothbrush.",
-          "poll_interval": "How often (in seconds) to poll the device. Minimum 60 s. Default: 300 s (5 min)."
+          "poll_interval": "How often (in seconds) to poll the device. Minimum 60 s, or 0 to disable automatic polling. Default: 300 s (5 min)."
         }
       },
       "confirm": {

--- a/custom_components/oclean_ble/translations/es.json
+++ b/custom_components/oclean_ble/translations/es.json
@@ -23,7 +23,7 @@
         },
         "data_description": {
           "mac_address": "La dirección MAC Bluetooth de tu cepillo Oclean.",
-          "poll_interval": "Cada cuánto (en segundos) se sondea el dispositivo. Mínimo 60 s. Predeterminado: 300 s (5 min)."
+          "poll_interval": "Cada cuánto (en segundos) se sondea el dispositivo. Mínimo 60 s, o 0 para desactivar el sondeo automático. Predeterminado: 300 s (5 min)."
         }
       },
       "confirm": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,12 +1,16 @@
 """Tests for config_flow.py – validates schema logic and MAC validation."""
+
 from __future__ import annotations
 
 import pytest
 
 # conftest.py stubs HA before these imports
+import voluptuous as vol
+
 from custom_components.oclean_ble.config_flow import (
     _MAC_RE,
     _parse_windows_list,
+    _validate_poll_interval,
     _windows_list_to_str,
 )
 from custom_components.oclean_ble.const import (
@@ -18,22 +22,23 @@ from custom_components.oclean_ble.const import (
 # MAC address regex validation
 # ---------------------------------------------------------------------------
 
+
 class TestMacAddressRegex:
     VALID = [
         "AA:BB:CC:DD:EE:FF",
         "00:11:22:33:44:55",
-        "a0:b1:c2:d3:e4:f5",   # lowercase
-        "A0:B1:C2:D3:E4:F5",   # uppercase
+        "a0:b1:c2:d3:e4:f5",  # lowercase
+        "A0:B1:C2:D3:E4:F5",  # uppercase
     ]
     INVALID = [
-        "AA:BB:CC:DD:EE",          # only 5 octets
-        "AA:BB:CC:DD:EE:FF:00",    # 7 octets
-        "AABBCCDDEEFF",            # no colons
-        "AA-BB-CC-DD-EE-FF",       # hyphens
-        "GG:BB:CC:DD:EE:FF",       # invalid hex
+        "AA:BB:CC:DD:EE",  # only 5 octets
+        "AA:BB:CC:DD:EE:FF:00",  # 7 octets
+        "AABBCCDDEEFF",  # no colons
+        "AA-BB-CC-DD-EE-FF",  # hyphens
+        "GG:BB:CC:DD:EE:FF",  # invalid hex
         "",
         "AA:BB:CC:DD:EE:GG",
-        "AA:BB:CC:DD:EE:F",        # too short last octet
+        "AA:BB:CC:DD:EE:F",  # too short last octet
     ]
 
     @pytest.mark.parametrize("mac", VALID)
@@ -49,6 +54,7 @@ class TestMacAddressRegex:
 # Poll interval constants
 # ---------------------------------------------------------------------------
 
+
 class TestPollIntervalConstants:
     def test_default_is_5_minutes(self):
         assert DEFAULT_POLL_INTERVAL == 300
@@ -61,8 +67,37 @@ class TestPollIntervalConstants:
 
 
 # ---------------------------------------------------------------------------
+# Poll interval validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePollInterval:
+    def test_zero_is_allowed(self):
+        assert _validate_poll_interval(0) == 0
+
+    def test_minimum_is_allowed(self):
+        assert _validate_poll_interval(MIN_POLL_INTERVAL) == MIN_POLL_INTERVAL
+
+    def test_above_minimum_is_allowed(self):
+        assert _validate_poll_interval(300) == 300
+
+    def test_between_1_and_59_is_rejected(self):
+        with pytest.raises(vol.Invalid):
+            _validate_poll_interval(30)
+
+    def test_59_is_rejected(self):
+        with pytest.raises(vol.Invalid):
+            _validate_poll_interval(59)
+
+    def test_negative_is_rejected(self):
+        with pytest.raises(vol.Invalid):
+            _validate_poll_interval(-1)
+
+
+# ---------------------------------------------------------------------------
 # Config flow input normalization
 # ---------------------------------------------------------------------------
+
 
 class TestMacNormalization:
     """The config flow calls .upper().strip() on the MAC before validation."""
@@ -86,6 +121,7 @@ class TestMacNormalization:
 # ---------------------------------------------------------------------------
 # Poll window helpers
 # ---------------------------------------------------------------------------
+
 
 class TestParseWindowsList:
     def test_empty_string_returns_empty(self):


### PR DESCRIPTION
Fixes #51.

## Summary

- The config flow used `vol.Range(min=60)` in all three setup steps (`confirm`, `pick_device`, `manual`), which rejected `0` even though `0` is a valid sentinel for "no automatic polling / manual only"
- Adds `_validate_poll_interval()` helper that accepts `0` or `>= MIN_POLL_INTERVAL (60)`, replacing the three `vol.Range` validators
- Updates translation descriptions (EN/DE/ES) to mention that `0` disables automatic polling
- Adds `TestValidatePollInterval` test class with 6 cases

## Note

The options flow (post-setup settings) was already fixed in `feat/issue-39-manual-poll-action` via its `NumberSelector(min=0)`. This PR covers the initial setup wizard which that branch did not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)