### PR TITLE
test: add per-model integration tests (OCLEANY3M, OCLEANY3P, OCLEANA1)

### DIFF
--- a/tests/integration_helpers.py
+++ b/tests/integration_helpers.py
@@ -1,0 +1,62 @@
+"""Shared helpers for per-model integration tests.
+
+Provides factory functions and a poll runner used by all three per-model
+integration test modules (test_integration_ocleana1, test_integration_ocleany3m,
+test_integration_ocleany3p).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.oclean_ble.coordinator import OcleanCoordinator
+
+
+def make_coordinator(mac: str, name: str) -> OcleanCoordinator:
+    """Create a minimal OcleanCoordinator with HA storage pre-loaded."""
+    hass = MagicMock()
+    hass.data = {}
+    coord = OcleanCoordinator(hass, mac, name, 300)
+    coord._store_loaded = True
+    return coord
+
+
+def make_service_info(mac: str):
+    """Create a minimal BluetoothServiceInfo mock for the given MAC."""
+    device = MagicMock()
+    device.address = mac
+    si = MagicMock()
+    si.device = device
+    return si
+
+
+async def run_poll(coordinator: OcleanCoordinator, client: AsyncMock) -> dict:
+    """Run coordinator._poll_device() with all external dependencies mocked.
+
+    Patches:
+      - bluetooth.async_last_service_info → minimal service-info for coordinator MAC
+      - establish_connection               → returns the provided client mock
+      - asyncio.sleep                      → no-op (speeds up tests)
+      - coordinator._paginate_sessions     → no-op (unit-tested separately)
+      - import_new_sessions                → returns 0
+    """
+    with (
+        patch("custom_components.oclean_ble.coordinator.bluetooth") as bt_mock,
+        patch(
+            "custom_components.oclean_ble.coordinator.establish_connection",
+            new_callable=AsyncMock,
+            return_value=client,
+        ),
+        patch(
+            "custom_components.oclean_ble.coordinator.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+        patch.object(coordinator, "_paginate_sessions", new_callable=AsyncMock),
+        patch(
+            "custom_components.oclean_ble.coordinator.import_new_sessions",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+    ):
+        bt_mock.async_last_service_info.return_value = make_service_info(coordinator._mac)
+        return await coordinator._poll_device()

--- a/tests/simulator.py
+++ b/tests/simulator.py
@@ -17,6 +17,7 @@ Usage (builder pattern)::
         .build_client()
     )
 """
+
 from __future__ import annotations
 
 import struct
@@ -257,6 +258,7 @@ class OcleanDeviceSimulator:
         self._battery: int = 75
         self._notifications: list[bytes] = []
         self._notify_errors: dict[str, type[Exception] | Exception] = {}
+        self._read_char_responses: dict[str, bytes] = {}
 
     def with_battery(self, battery: int) -> OcleanDeviceSimulator:
         """Set the battery level returned by the GATT Battery Characteristic read."""
@@ -269,6 +271,19 @@ class OcleanDeviceSimulator:
     ) -> OcleanDeviceSimulator:
         """Make start_notify raise for specific characteristic UUIDs (simulates OCLEANA1)."""
         self._notify_errors = errors
+        return self
+
+    def with_read_char_responses(
+        self,
+        responses: dict[str, bytes],
+    ) -> OcleanDeviceSimulator:
+        """Override read_gatt_char return values for specific characteristic UUIDs.
+
+        Keys are full UUID strings (e.g. READ_NOTIFY_CHAR_UUID).
+        Values are the raw bytes to return for that UUID.
+        UUIDs not listed fall back to bytearray([battery]).
+        """
+        self._read_char_responses.update(responses)
         return self
 
     def add_notification(self, data: bytes) -> OcleanDeviceSimulator:
@@ -291,9 +306,7 @@ class OcleanDeviceSimulator:
     ) -> OcleanDeviceSimulator:
         """Add a Type-1 (0307) session push notification (Oclean X / OCLEANY3M)."""
         self._notifications.append(
-            build_0307_payload(
-                year, month, day, hour, minute, second, pnum, duration, valid_duration
-            )
+            build_0307_payload(year, month, day, hour, minute, second, pnum, duration, valid_duration)
         )
         return self
 
@@ -315,8 +328,17 @@ class OcleanDeviceSimulator:
         """Add an extended (0308) session notification (Oclean X Pro / OCLEANY3)."""
         self._notifications.append(
             build_0308_extended_payload(
-                year, month, day, hour, minute, second,
-                pnum, duration, score, area_pressures, tz_offset_quarters,
+                year,
+                month,
+                day,
+                hour,
+                minute,
+                second,
+                pnum,
+                duration,
+                score,
+                area_pressures,
+                tz_offset_quarters,
             )
         )
         return self
@@ -334,6 +356,65 @@ class OcleanDeviceSimulator:
         self._notifications.append(build_2604_payload(area_pressures))
         return self
 
+    def add_y3p_stream_session(
+        self,
+        month: int,
+        day: int,
+        hour: int,
+        minute: int,
+        second: int,
+        *,
+        duration: int,
+        score: int,
+        area_pressures: tuple = (0, 0, 0, 0, 0, 0, 0, 0),
+    ) -> OcleanDeviceSimulator:
+        """Add a single OCLEANY3P *B# stream session (1 record = 42 bytes).
+
+        OCLEANY3P announces one session via a 0307 *B# header (count=1, year_byte=0),
+        then the coordinator accumulates continuation packets until 42 bytes arrive.
+
+        The 42-byte Y3P record layout::
+
+          byte  0:   0x00 (year_byte – not stored on device)
+          bytes 1-5: month / day / hour / minute / second
+          byte  6:   0x00 (reserved)
+          bytes 7-8: duration, big-endian uint16 (seconds)
+          bytes 9-20: 0x00 (reserved)
+          bytes 21-28: 8 tooth-area pressure values
+          bytes 29-32: 0x00 (reserved)
+          byte  33:  brushing score (0-100; 0xFF = absent)
+          bytes 34-41: 0x00 (padding)
+
+        The record is split across 3 BLE packets:
+          - 0307 header (20 bytes): prefix + *B# magic + count=1 + record[0:13]
+          - continuation 1  (20 bytes): record[13:33]
+          - continuation 2   (9 bytes): record[33:42]
+        """
+        record = bytearray(42)
+        record[0] = 0x00
+        record[1] = month
+        record[2] = day
+        record[3] = hour
+        record[4] = minute
+        record[5] = second
+        record[7] = (duration >> 8) & 0xFF
+        record[8] = duration & 0xFF
+        for i, p in enumerate(area_pressures[:8]):
+            record[21 + i] = int(p) & 0xFF
+        record[33] = max(0, min(255, score))
+
+        header = bytearray(20)
+        header[0:2] = b"\x03\x07"
+        header[2:5] = b"\x2a\x42\x23"  # *B#
+        header[5] = 0x00  # count high byte
+        header[6] = 0x01  # count low byte (1 record)
+        header[7:20] = record[0:13]
+
+        self._notifications.append(bytes(header))
+        self._notifications.append(bytes(record[13:33]))  # 20 bytes
+        self._notifications.append(bytes(record[33:42]))  # 9 bytes
+        return self
+
     def add_session_meta(
         self,
         year: int,
@@ -346,9 +427,7 @@ class OcleanDeviceSimulator:
         duration: int,
     ) -> OcleanDeviceSimulator:
         """Add a 5a00 session-meta push notification."""
-        self._notifications.append(
-            build_5a00_payload(year, month, day, hour, minute, second, duration)
-        )
+        self._notifications.append(build_5a00_payload(year, month, day, hour, minute, second, duration))
         return self
 
     def build_client(self) -> AsyncMock:
@@ -361,13 +440,20 @@ class OcleanDeviceSimulator:
         notifications = list(self._notifications)
         battery = self._battery
         notify_errors = dict(self._notify_errors)
+        read_responses = dict(self._read_char_responses)
 
         client = AsyncMock()
         client.is_connected = True
         client.write_gatt_char = AsyncMock()
         client.stop_notify = AsyncMock()
         client.disconnect = AsyncMock()
-        client.read_gatt_char = AsyncMock(return_value=bytearray([battery]))
+
+        async def _read_gatt_char(uuid: str) -> bytearray:
+            if uuid in read_responses:
+                return bytearray(read_responses[uuid])
+            return bytearray([battery])
+
+        client.read_gatt_char = AsyncMock(side_effect=_read_gatt_char)
 
         call_count = [0]
 

--- a/tests/test_integration_ocleana1.py
+++ b/tests/test_integration_ocleana1.py
@@ -1,0 +1,185 @@
+"""Integration tests for Oclean Air 1 (OCLEANA1).
+
+OCLEANA1 cannot subscribe to BLE notifications on READ_NOTIFY_CHAR_UUID (fbb86)
+because that characteristic has no CCCD descriptor.  The coordinator detects this
+at runtime: if fbb86 is not in the subscribed set after _subscribe_notifications(),
+it falls back to a direct GATT read of that characteristic.
+
+Real device behaviour (logs/20260313_#7_bato2000_oclean_ble.log):
+  - start_notify(fbb86, …)  → BleakError (no CCCD)
+  - coordinator calls _read_response_char_fallback()
+  - read_gatt_char(READ_NOTIFY_CHAR_UUID) → b'' (empty, device cleared the value)
+  - battery = 0x35 = 53 from direct GATT read of 0x2A19
+
+Protocol note:  OCLEANA1 is classified as Legacy once the model_id is known;
+in tests the coordinator starts as UNKNOWN but the read-fallback is triggered by
+the BleakError on fbb86 regardless of protocol, because UNKNOWN still tries to
+subscribe to fbb86 and will fail the same way.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.oclean_ble.const import (
+    DATA_BATTERY,
+    DATA_LAST_BRUSH_DURATION,
+    DATA_LAST_BRUSH_SCORE,
+    DATA_LAST_BRUSH_TIME,
+    READ_NOTIFY_CHAR_UUID,
+)
+from tests.integration_helpers import make_coordinator, run_poll
+from tests.simulator import OcleanDeviceSimulator
+
+_MAC = "70:28:45:5F:AC:C1"
+
+
+def _coordinator():
+    return make_coordinator(_MAC, "Oclean Air 1")
+
+
+# ---------------------------------------------------------------------------
+# TestOcleanA1ReadFallback
+# ---------------------------------------------------------------------------
+
+
+class TestOcleanA1ReadFallback:
+    """OCLEANA1: fbb86 subscribe fails → direct GATT READ fallback is triggered.
+
+    When READ_NOTIFY_CHAR_UUID (fbb86) cannot be subscribed, the coordinator
+    must fall back to reading the characteristic value directly.  This class
+    tests the complete poll pipeline for this device type.
+    """
+
+    @pytest.mark.asyncio
+    async def test_poll_completes_without_crash(self):
+        """Poll must complete (return dict) even when fbb86 subscribe fails."""
+        from bleak import BleakError
+
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(53)
+            .with_notify_errors({READ_NOTIFY_CHAR_UUID: BleakError("no CCCD")})
+            .with_read_char_responses({READ_NOTIFY_CHAR_UUID: b""})
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_battery_from_gatt_read(self):
+        """Battery must be read from 0x2A19 GATT char when 0303 notification is missed.
+
+        Because fbb86 is not subscribed, the 0303 STATE response is never received
+        via notification.  Battery comes from the direct read_gatt_char(BATTERY_CHAR_UUID).
+        """
+        from bleak import BleakError
+
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(53)
+            .with_notify_errors({READ_NOTIFY_CHAR_UUID: BleakError("no CCCD")})
+            .with_read_char_responses({READ_NOTIFY_CHAR_UUID: b""})
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result[DATA_BATTERY] == 53
+
+    @pytest.mark.asyncio
+    async def test_no_session_when_fallback_returns_empty(self):
+        """Empty READ fallback response → no session fields in result.
+
+        This mirrors the real OCLEANA1 log where the device returned b'' from fbb86.
+        """
+        from bleak import BleakError
+
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(53)
+            .with_notify_errors({READ_NOTIFY_CHAR_UUID: BleakError("no CCCD")})
+            .with_read_char_responses({READ_NOTIFY_CHAR_UUID: b""})
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result.get(DATA_LAST_BRUSH_TIME) is None
+        assert result.get(DATA_LAST_BRUSH_SCORE) is None
+        assert result.get(DATA_LAST_BRUSH_DURATION) is None
+
+    @pytest.mark.asyncio
+    async def test_state_parsed_when_fallback_returns_0303_bytes(self):
+        """If fbb86 holds a valid 0303 response, battery is set from that notification.
+
+        Some device revisions may store the last notification as the readable value.
+        The coordinator must parse the bytes received via READ exactly like a push
+        notification.
+
+        Execution order is deterministic: _read_response_char_fallback() runs before
+        _read_battery_and_unsubscribe(), which skips the GATT read once DATA_BATTERY
+        is already in collected.  Battery therefore comes from the 0303 parse (40),
+        not from the GATT read (0).
+        """
+        from bleak import BleakError
+
+        # 0303 STATE: is_brushing=False, battery=40
+        state_bytes = bytes.fromhex("0303020e46280200")
+
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(0)  # GATT read would return 0 – skipped because 0303 sets battery first
+            .with_notify_errors({READ_NOTIFY_CHAR_UUID: BleakError("no CCCD")})
+            .with_read_char_responses({READ_NOTIFY_CHAR_UUID: state_bytes})
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result[DATA_BATTERY] == 40
+
+    @pytest.mark.asyncio
+    async def test_read_fallback_exception_handled_gracefully(self):
+        """If read_gatt_char(fbb86) raises, the poll must still complete.
+
+        Double-failure scenario: fbb86 subscribe fails (no CCCD) AND the
+        subsequent direct read also raises.  The coordinator catches the
+        exception and the poll finishes normally; battery comes from 0x2A19.
+        """
+        from bleak import BleakError
+
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(53)
+            .with_notify_errors({READ_NOTIFY_CHAR_UUID: BleakError("no CCCD")})
+            .build_client()
+        )
+
+        async def _raising_read(uuid: str) -> bytearray:
+            if uuid == READ_NOTIFY_CHAR_UUID:
+                raise BleakError("read failed too")
+            return bytearray([53])
+
+        client.read_gatt_char = AsyncMock(side_effect=_raising_read)
+
+        result = await run_poll(_coordinator(), client)
+        assert isinstance(result, dict)
+        assert result[DATA_BATTERY] == 53
+
+    @pytest.mark.asyncio
+    async def test_read_fallback_not_triggered_when_fbb86_subscribed(self):
+        """When fbb86 subscribes successfully, the READ fallback must NOT be called.
+
+        Validates that read_gatt_char(fbb86) is only called when subscription failed.
+        """
+        fbb86_reads: list[str] = []
+
+        async def _tracking_read(uuid: str) -> bytearray:
+            if uuid == READ_NOTIFY_CHAR_UUID:
+                fbb86_reads.append(uuid)
+            return bytearray([75])
+
+        client = OcleanDeviceSimulator().with_battery(75).build_client()
+        # Patch read_gatt_char on the already-built client to track calls
+        client.read_gatt_char = AsyncMock(side_effect=_tracking_read)
+
+        await run_poll(_coordinator(), client)
+
+        assert fbb86_reads == [], "read_gatt_char(fbb86) must NOT be called when subscription succeeded"

--- a/tests/test_integration_ocleany3m.py
+++ b/tests/test_integration_ocleany3m.py
@@ -1,0 +1,189 @@
+"""Integration tests for Oclean X / Oclean X Pro Elite (OCLEANY3M / OCLEANY3MH).
+
+These tests feed real BLE notification bytes captured from a live OCLEANY3MH device
+(log: logs/20260311_#19_NicGray78_v2.log) through the complete coordinator pipeline
+and assert on the resulting OcleanDeviceData field values.
+
+Device model:  OCLEANY3MH (Oclean X)
+Protocol:      Type-1 – 0307 *B# multi-packet reassembly
+Session path:  0307 header + continuation packets → parse_t1_c3352g_record()
+               (not 2604 / 0000 push notifications)
+
+Real poll sequence captured in log (2026-03-11 20:08:22):
+  0303020e461b0100                        → battery=27, is_brushing=False
+  03072a422300011a030b14021700007800780514 → *B# header (1 record, inline 13 B)
+  4b0000001f00000000001c14190c0a0a0a000000 → continuation (+20 B, 33/42 total)
+  5b030301ffffffffff1a0306071e0f0000780078 → continuation (+20 B, 53/42 → flush)
+
+Expected parsed values (confirmed from log line 26):
+  last_brush_time     = 1773219743
+  last_brush_duration = 120
+  last_brush_score    = 91
+  last_brush_pnum     = 0
+  last_brush_pressure = 12
+  last_brush_areas    = {upper_left_out: 5, upper_left_in: 20,
+                          lower_left_out: 75, lower_left_in: 0,
+                          upper_right_out: 0, upper_right_in: 0,
+                          lower_right_out: 0, lower_right_in: 0}
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.oclean_ble.const import (
+    DATA_BATTERY,
+    DATA_LAST_BRUSH_AREAS,
+    DATA_LAST_BRUSH_DURATION,
+    DATA_LAST_BRUSH_PNUM,
+    DATA_LAST_BRUSH_PRESSURE,
+    DATA_LAST_BRUSH_SCORE,
+    DATA_LAST_BRUSH_TIME,
+    TOOTH_AREA_NAMES,
+)
+from tests.integration_helpers import make_coordinator, run_poll
+from tests.simulator import OcleanDeviceSimulator
+
+# ---------------------------------------------------------------------------
+# Real bytes captured from OCLEANY3MH log (2026-03-11 20:08:22)
+# ---------------------------------------------------------------------------
+
+# STATE: is_brushing=False, battery=27
+_BYTES_0303 = bytes.fromhex("0303020e461b0100")
+
+# 0307 *B# header: count=1 record, inline record[0:13]
+# record[0]=0x1a (year_base=2026), [1]=03 [2]=0b [3]=14 [4]=02 [5]=17 → 2026-03-11 20:02:23
+# pnum=0, duration=120s
+_BYTES_0307_HEADER = bytes.fromhex("03072a422300011a030b14021700007800780514")
+
+# continuation +20 B: record[13:33]
+_BYTES_CONT1 = bytes.fromhex("4b0000001f00000000001c14190c0a0a0a000000")
+
+# continuation +20 B: record[33:42 + extra] → completes the 42-byte record (flush)
+_BYTES_CONT2 = bytes.fromhex("5b030301ffffffffff1a0306071e0f0000780078")
+
+# Expected parsed values (from log "poll collected so far")
+_EXPECTED_TS = 1773219743
+_EXPECTED_DURATION = 120
+_EXPECTED_SCORE = 91
+_EXPECTED_PNUM = 0
+_EXPECTED_PRESSURE = 12
+_EXPECTED_AREAS = {
+    "upper_left_out": 5,
+    "upper_left_in": 20,
+    "lower_left_out": 75,
+    "lower_left_in": 0,
+    "upper_right_out": 0,
+    "upper_right_in": 0,
+    "lower_right_out": 0,
+    "lower_right_in": 0,
+}
+
+_MAC = "70:28:45:83:2A:C9"
+
+
+def _coordinator():
+    return make_coordinator(_MAC, "Oclean X")
+
+
+def _full_session_client():
+    """Client that delivers the complete 3-packet *B# session burst."""
+    return (
+        OcleanDeviceSimulator()
+        .with_battery(27)
+        .add_notification(_BYTES_0303)
+        .add_notification(_BYTES_0307_HEADER)
+        .add_notification(_BYTES_CONT1)
+        .add_notification(_BYTES_CONT2)
+        .build_client()
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestOcleanY3MRealData – real bytes from OCLEANY3MH log
+# ---------------------------------------------------------------------------
+
+
+class TestOcleanY3MRealData:
+    """End-to-end poll using verbatim notification bytes from OCLEANY3MH device.
+
+    Validates that the *B# multi-packet reassembly in the coordinator correctly
+    accumulates the three packets and the C3352g parser extracts all fields.
+    """
+
+    @pytest.mark.asyncio
+    async def test_battery_from_0303_notification(self):
+        """Battery is parsed from the 0303 STATE notification."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert result[DATA_BATTERY] == 27
+
+    @pytest.mark.asyncio
+    async def test_session_timestamp_correct(self):
+        """Timestamp decoded from *B# record is close to the device log value.
+
+        The parser uses time.mktime() which is timezone-dependent.  We accept
+        timestamps within ±14 h of the UTC reference (covers UTC-14 … UTC+14).
+        """
+        result = await run_poll(_coordinator(), _full_session_client())
+        ts = result[DATA_LAST_BRUSH_TIME]
+        assert abs(ts - _EXPECTED_TS) <= 14 * 3600, f"Timestamp {ts} too far from expected {_EXPECTED_TS}"
+
+    @pytest.mark.asyncio
+    async def test_session_duration_correct(self):
+        """Duration (seconds) decoded from *B# record matches the device log."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert result[DATA_LAST_BRUSH_DURATION] == _EXPECTED_DURATION
+
+    @pytest.mark.asyncio
+    async def test_session_score_correct(self):
+        """Brushing score (0-100) decoded from *B# record matches the device log."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert result[DATA_LAST_BRUSH_SCORE] == _EXPECTED_SCORE
+
+    @pytest.mark.asyncio
+    async def test_session_pnum_correct(self):
+        """Brush-scheme pNum decoded from *B# record matches the device log."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert result[DATA_LAST_BRUSH_PNUM] == _EXPECTED_PNUM
+
+    @pytest.mark.asyncio
+    async def test_session_areas_correct(self):
+        """All 8 tooth-area pressures decoded from *B# record match the device log."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert result[DATA_LAST_BRUSH_AREAS] == _EXPECTED_AREAS
+
+    @pytest.mark.asyncio
+    async def test_session_pressure_is_average(self):
+        """last_brush_pressure is the average of the non-zero area values."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert result[DATA_LAST_BRUSH_PRESSURE] == _EXPECTED_PRESSURE
+
+    @pytest.mark.asyncio
+    async def test_all_area_names_present(self):
+        """last_brush_areas dict contains exactly the 8 canonical zone names."""
+        result = await run_poll(_coordinator(), _full_session_client())
+        assert set(result[DATA_LAST_BRUSH_AREAS].keys()) == set(TOOTH_AREA_NAMES)
+
+    @pytest.mark.asyncio
+    async def test_no_session_when_only_0303_received(self):
+        """Poll with only a 0303 STATE notification yields battery but no session."""
+        client = OcleanDeviceSimulator().with_battery(27).add_notification(_BYTES_0303).build_client()
+        result = await run_poll(_coordinator(), client)
+        assert result[DATA_BATTERY] == 27
+        assert result.get(DATA_LAST_BRUSH_TIME) is None
+        assert result.get(DATA_LAST_BRUSH_SCORE) is None
+
+    @pytest.mark.asyncio
+    async def test_incomplete_star_b_hash_no_session(self):
+        """If the *B# buffer never fills (only header + 1 continuation), no session is emitted."""
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(27)
+            .add_notification(_BYTES_0307_HEADER)
+            .add_notification(_BYTES_CONT1)
+            # _BYTES_CONT2 is intentionally omitted → buffer stays at 33/42 bytes
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result.get(DATA_LAST_BRUSH_TIME) is None
+        assert result.get(DATA_LAST_BRUSH_SCORE) is None

--- a/tests/test_integration_ocleany3p.py
+++ b/tests/test_integration_ocleany3p.py
@@ -1,0 +1,186 @@
+"""Integration tests for Oclean X Pro Elite (OCLEANY3P).
+
+OCLEANY3P uses the *B# multi-packet stream protocol where the device signals
+session_count > 0 with year_byte = 0x00 in the 0307 response.  The coordinator
+then accumulates continuation packets until all session records are complete,
+and calls ``parse_y3p_stream_record()`` on each 42-byte chunk.
+
+Y3P stream record layout (42 bytes):
+  byte  0:   0x00 – year not stored; inferred from wall clock
+  bytes 1-5: month / day / hour / minute / second
+  byte  6:   reserved (0x00)
+  bytes 7-8: duration, big-endian uint16 (seconds)
+  bytes 9-20:  reserved
+  bytes 21-28: 8 tooth-area pressure values
+  bytes 29-32: reserved
+  byte  33:  brushing score (0-100; 0xFF = absent)
+  bytes 34-41: padding
+
+These tests use the ``add_y3p_stream_session`` simulator builder which constructs
+the three BLE packets that carry one 42-byte record.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.oclean_ble.const import (
+    DATA_BATTERY,
+    DATA_LAST_BRUSH_AREAS,
+    DATA_LAST_BRUSH_DURATION,
+    DATA_LAST_BRUSH_PRESSURE,
+    DATA_LAST_BRUSH_SCORE,
+    DATA_LAST_BRUSH_TIME,
+    TOOTH_AREA_NAMES,
+)
+from tests.integration_helpers import make_coordinator, run_poll
+from tests.simulator import OcleanDeviceSimulator
+
+_MAC = "AA:BB:CC:DD:EE:F5"
+
+
+def _coordinator():
+    return make_coordinator(_MAC, "Oclean X Pro Elite")
+
+
+# ---------------------------------------------------------------------------
+# TestOcleanY3PStreamSession – Y3P *B# stream protocol
+# ---------------------------------------------------------------------------
+
+
+class TestOcleanY3PStreamSession:
+    """OCLEANY3P *B# multi-packet stream: one 42-byte record across 3 BLE packets.
+
+    The OcleanDeviceSimulator.add_y3p_stream_session() method builds the
+    correct 0307 header + 2 continuation packets for a single Y3P record.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_all_fields_present(self):
+        """Y3P stream → duration, score, areas, and pressure all populated."""
+        areas = (10, 20, 30, 15, 25, 35, 5, 10)
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(65)
+            .add_y3p_stream_session(
+                3,
+                11,
+                20,
+                2,
+                23,
+                duration=120,
+                score=88,
+                area_pressures=areas,
+            )
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+
+        assert result[DATA_BATTERY] == 65
+        assert result[DATA_LAST_BRUSH_DURATION] == 120
+        assert result[DATA_LAST_BRUSH_SCORE] == 88
+        assert isinstance(result[DATA_LAST_BRUSH_AREAS], dict)
+        assert len(result[DATA_LAST_BRUSH_AREAS]) == 8
+        assert result[DATA_LAST_BRUSH_PRESSURE] > 0
+
+    @pytest.mark.asyncio
+    async def test_session_timestamp_is_set(self):
+        """Y3P stream record produces a non-zero timestamp."""
+        client = OcleanDeviceSimulator().add_y3p_stream_session(3, 11, 20, 2, 23, duration=120, score=88).build_client()
+        result = await run_poll(_coordinator(), client)
+        assert result.get(DATA_LAST_BRUSH_TIME) is not None
+        assert result[DATA_LAST_BRUSH_TIME] > 0
+
+    @pytest.mark.asyncio
+    async def test_area_values_match_input(self):
+        """Area pressures are stored in the canonical zone-name order."""
+        areas = (1, 2, 3, 4, 5, 6, 7, 8)
+        client = (
+            OcleanDeviceSimulator()
+            .add_y3p_stream_session(3, 11, 20, 2, 23, duration=90, score=70, area_pressures=areas)
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        area_dict = result[DATA_LAST_BRUSH_AREAS]
+        for i, name in enumerate(TOOTH_AREA_NAMES):
+            assert area_dict[name] == areas[i], f"Mismatch for zone {name}"
+
+    @pytest.mark.asyncio
+    async def test_pressure_is_rounded_average_of_areas(self):
+        """last_brush_pressure is the rounded average of the 8 area values.
+
+        Uses areas where round() and int() differ: sum=7, /8=0.875
+          round(0.875) = 1  (correct)
+          int(0.875)   = 0  (wrong – would mean floor, not round)
+        """
+        areas = (7, 0, 0, 0, 0, 0, 0, 0)  # sum=7 / 8 = 0.875 → round=1, int=0
+        client = (
+            OcleanDeviceSimulator()
+            .add_y3p_stream_session(3, 11, 20, 2, 23, duration=90, score=70, area_pressures=areas)
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result[DATA_LAST_BRUSH_PRESSURE] == 1
+
+    @pytest.mark.asyncio
+    async def test_score_0xff_not_set(self):
+        """Y3P record with score byte = 0xFF must leave last_brush_score absent."""
+        client = (
+            OcleanDeviceSimulator().add_y3p_stream_session(3, 11, 20, 2, 23, duration=90, score=0xFF).build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result.get(DATA_LAST_BRUSH_SCORE) is None
+
+    @pytest.mark.asyncio
+    async def test_no_areas_when_all_pressures_zero(self):
+        """Y3P record with all area bytes = 0 must leave last_brush_areas absent."""
+        client = (
+            OcleanDeviceSimulator()
+            .add_y3p_stream_session(3, 11, 20, 2, 23, duration=90, score=70, area_pressures=(0,) * 8)
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result.get(DATA_LAST_BRUSH_AREAS) is None
+        assert result.get(DATA_LAST_BRUSH_PRESSURE) is None
+
+    @pytest.mark.asyncio
+    async def test_battery_only_when_no_session(self):
+        """Poll with no session notifications yields only battery."""
+        client = OcleanDeviceSimulator().with_battery(65).build_client()
+        result = await run_poll(_coordinator(), client)
+        assert result[DATA_BATTERY] == 65
+        assert result.get(DATA_LAST_BRUSH_TIME) is None
+
+    @pytest.mark.asyncio
+    async def test_incomplete_stream_no_session(self):
+        """Only the 0307 header + first continuation (33/42 bytes) → no session emitted.
+
+        The *B# buffer must not flush until the full 42-byte record is received.
+        """
+        # Build 0307 header for 1 record manually to verify the partial-packet path.
+        record = bytearray(42)
+        record[0] = 0x00  # year_byte
+        record[1] = 3  # month
+        record[2] = 11  # day
+        record[3] = 20  # hour
+        record[7] = 0x00
+        record[8] = 0x78  # duration=120
+
+        header = bytearray(20)
+        header[0:2] = b"\x03\x07"
+        header[2:5] = b"\x2a\x42\x23"
+        header[5] = 0x00
+        header[6] = 0x01  # count=1
+        header[7:20] = record[0:13]
+
+        client = (
+            OcleanDeviceSimulator()
+            .with_battery(65)
+            .add_notification(bytes(header))
+            .add_notification(bytes(record[13:33]))  # +20 B → 33/42
+            # intentionally omitting the final 9-byte packet
+            .build_client()
+        )
+        result = await run_poll(_coordinator(), client)
+        assert result.get(DATA_LAST_BRUSH_TIME) is None
+        assert result.get(DATA_LAST_BRUSH_SCORE) is None


### PR DESCRIPTION
Three new test classes cover the complete BLE poll pipeline for each device model, from raw notification bytes to OcleanDeviceData field values:

- TestOcleanY3MRealData (test_integration_ocleany3m.py) Uses verbatim bytes from a real OCLEANY3MH device log to validate *B# multi-packet reassembly: battery, timestamp, duration, score, pnum, 8 tooth-area pressures, and incomplete-buffer guard.

- TestOcleanY3PStreamSession (test_integration_ocleany3p.py) Tests the OCLEANY3P *B# Y3P stream path (42-byte records split across 3 BLE packets): all fields present, score=0xFF absent, zero-area suppression, and partial-buffer no-session guard.

- TestOcleanA1ReadFallback (test_integration_ocleana1.py) Validates that fbb86 subscribe failure triggers the READ fallback, battery comes from GATT read, empty fallback yields no session, and a valid 0303 payload returned via READ is parsed correctly.

simulator.py is extended with:
  - with_read_char_responses(): UUID-specific read_gatt_char overrides
  - add_y3p_stream_session(): builds the 3-packet Y3P stream sequence