### PR TITLE
fix: clear stale enrichment and improve diagnostics for OCLEANY3P (#49)

### DIFF
--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -475,6 +475,18 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
 
         # Merge with last known persistent data, then overwrite with fresh values
         merged = {**{k: self._last_raw.get(k) for k in _PERSISTENT_KEYS}, **collected}
+
+        # Clear stale enrichment fields (score/areas/pressure) when a NEW session is
+        # detected but the current poll did not deliver enrichment data.  This prevents
+        # showing a previous session's score/areas alongside the current session's
+        # timestamp (e.g. OCLEANY3P inline mode where session_count=0 omits enrichment).
+        new_ts = collected.get(DATA_LAST_BRUSH_TIME, 0)
+        prev_ts = self._last_raw.get(DATA_LAST_BRUSH_TIME, 0)
+        if new_ts and new_ts > prev_ts:
+            for key in _ENRICHMENT_KEYS:
+                if key not in collected:
+                    merged.pop(key, None)
+
         self._last_raw = merged
 
         # Persist after every successful poll so that battery, model, and session
@@ -837,12 +849,19 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
                 subscribed.add(char_uuid)
                 self._log.debug("subscribed to %s", char_uuid)
             except Exception as err:  # noqa: BLE001
-                self._log.debug(
-                    "could not subscribe to %s: %s (%s)",
-                    char_uuid,
-                    err,
-                    type(err).__name__,
-                )
+                if "Notify acquired" in str(err):
+                    self._log.warning(
+                        "could not subscribe to %s: %s – close the Oclean app to allow polling",
+                        char_uuid,
+                        err,
+                    )
+                else:
+                    self._log.debug(
+                        "could not subscribe to %s: %s (%s)",
+                        char_uuid,
+                        err,
+                        type(err).__name__,
+                    )
         return frozenset(subscribed)
 
     async def _read_response_char_fallback(

--- a/custom_components/oclean_ble/parser.py
+++ b/custom_components/oclean_ble/parser.py
@@ -503,6 +503,14 @@ def parse_y3p_stream_record(record: bytes) -> dict[str, Any]:
         minute = record[4]
         second = record[5]
 
+        if month == 0:
+            _LOGGER.debug(
+                "Oclean Y3P stream record: device clock not synced (month=0), "
+                "sync via the Oclean app to fix timestamps (raw: %s)",
+                record[:T1_C3352G_RECORD_SIZE].hex(),
+            )
+            return {}
+
         now = datetime.datetime.now()
         year = now.year
         device_dt = datetime.datetime(year, month, day, hour, minute, second)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -470,9 +470,107 @@ class TestDataPersistence:
             bt_mock.async_last_service_info.return_value = _make_service_info()
             result = await coordinator._poll_device()
 
-        # Fresh battery overrides old; old score is carried forward
+        # Fresh battery overrides old; old score is carried forward (no new session)
         assert result[DATA_BATTERY] == 61
         assert result[DATA_LAST_BRUSH_SCORE] == 88
+
+    @pytest.mark.asyncio
+    async def test_stale_enrichment_cleared_on_new_session_without_enrichment(self):
+        """OCLEANY3P inline 0307 (session_count=0): stale score/areas/pressure must be
+        cleared when a new session timestamp arrives but no enrichment data is received.
+
+        Regression test for issue #49 (comment 13): after the first *B# poll the
+        device switches to session_count=0 inline mode which omits score/areas/pressure.
+        Without this fix those fields would show the previous session's values alongside
+        the new session's timestamp, giving misleading sensor readings.
+        """
+        coordinator = _make_coordinator()
+        coordinator._store_loaded = True
+        # Simulate last-known state: previous session with enrichment fields populated.
+        coordinator._last_raw = {
+            DATA_LAST_BRUSH_TIME: 1,  # old timestamp – any 2026 date will be newer
+            DATA_LAST_BRUSH_SCORE: 88,
+            DATA_LAST_BRUSH_AREAS: {"upper_left_out": 50},
+            DATA_LAST_BRUSH_PRESSURE: 14.0,
+            DATA_LAST_BRUSH_DURATION: 120,
+        }
+
+        # 0307 inline notification from OCLEANY3P with session_count=0 (year_byte=0x1a).
+        # Encodes 2026-03-19 23:05:53, pNum=75, duration=150 s – NO score/areas.
+        # Identical to the raw bytes logged in issue #49 comment 13.
+        notif_0307_inline = bytes.fromhex("03072a422300001a03131705354b009600960002")
+
+        client = _make_bleak_client(battery_value=41)
+
+        async def fake_start_notify(uuid, handler):
+            handler(None, bytearray(notif_0307_inline))
+
+        client.start_notify = AsyncMock(side_effect=fake_start_notify)
+
+        with (
+            patch("custom_components.oclean_ble.coordinator.bluetooth") as bt_mock,
+            patch(
+                "custom_components.oclean_ble.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=client,
+            ),
+            patch("custom_components.oclean_ble.coordinator.asyncio.sleep", new_callable=AsyncMock),
+            patch(
+                "custom_components.oclean_ble.coordinator.import_new_sessions", new_callable=AsyncMock, return_value=0
+            ),
+        ):
+            bt_mock.async_last_service_info.return_value = _make_service_info()
+            result = await coordinator._poll_device()
+
+        # New session timestamp must be present (inline 0307 parsed correctly)
+        assert DATA_LAST_BRUSH_TIME in result
+        assert result[DATA_LAST_BRUSH_TIME] > 1, "New timestamp must be newer than the old one"
+        # Duration from the inline notification
+        assert result.get(DATA_LAST_BRUSH_DURATION) == 150
+
+        # Stale enrichment from previous session must be cleared
+        assert result.get(DATA_LAST_BRUSH_SCORE) is None, (
+            "Stale score from previous session must not be shown for new session"
+        )
+        assert result.get(DATA_LAST_BRUSH_AREAS) is None, (
+            "Stale areas from previous session must not be shown for new session"
+        )
+        assert result.get(DATA_LAST_BRUSH_PRESSURE) is None, (
+            "Stale pressure from previous session must not be shown for new session"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enrichment_preserved_when_no_new_session(self):
+        """Stale enrichment must NOT be cleared when no new session is detected.
+
+        When the device returns the same session timestamp (e.g. repeated polls
+        between brushing events), score/areas/pressure from _last_raw must be kept.
+        """
+        coordinator = _make_coordinator()
+        coordinator._last_raw = {
+            DATA_BATTERY: 60,
+            DATA_LAST_BRUSH_SCORE: 77,
+            DATA_LAST_BRUSH_AREAS: {"upper_left_out": 30},
+            DATA_LAST_BRUSH_PRESSURE: 12.0,
+        }
+        # No session notification fired – collected has no DATA_LAST_BRUSH_TIME
+        client = _make_bleak_client(battery_value=60)
+
+        with (
+            patch("custom_components.oclean_ble.coordinator.bluetooth") as bt_mock,
+            patch(
+                "custom_components.oclean_ble.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=client,
+            ),
+            patch("custom_components.oclean_ble.coordinator.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            bt_mock.async_last_service_info.return_value = _make_service_info()
+            result = await coordinator._poll_device()
+
+        assert result.get(DATA_LAST_BRUSH_SCORE) == 77, "Score must be preserved when no new session"
+        assert result.get(DATA_LAST_BRUSH_AREAS) == {"upper_left_out": 30}
+        assert result.get(DATA_LAST_BRUSH_PRESSURE) == 12.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three targeted fixes for issues reported in issue #49:

**Fix 1 – coordinator: clear stale score/areas/pressure on new session** When OCLEANY3P reports session_count=0 in the 0307 response (inline mode), only time/pNum/duration are delivered. Previously the _last_raw merge kept the previous session's score/areas/pressure alongside the new session's timestamp, showing misleading sensor values.

Now: when a new session timestamp (new_ts > prev_ts) arrives without enrichment data in collected, the stale enrichment fields are removed from merged so sensors correctly show "unavailable" for the current session. OCLEANY3M is unaffected – its 0000/2604 enrichment lands in collected and is therefore not cleared.

**Fix 2 – parser: explicit month=0 check in Y3P stream record** After a device full reset (unsynced clock) Y3P records have month=0. Previously the error propagated to the datetime constructor producing the opaque message "month must be in 1..12, not 0". Now the check is explicit with a clear "device clock not synced (month=0), sync via the Oclean app" message so users can diagnose the cause without reading source code.

**Fix 3 – coordinator: Notify acquired logged at WARNING** When the Oclean app holds a BLE subscription to fbb86/fbb90 the integration cannot poll. Previously the failure was silent (DEBUG only). Now any "Notify acquired" subscription failure is logged at WARNING with actionable guidance to close the app.