### PR TITLE
fix: recover B# session stream truncated by slow ESPHome BLE proxy

### DIFF
--- a/custom_components/oclean_ble/const.py
+++ b/custom_components/oclean_ble/const.py
@@ -92,8 +92,11 @@ BLE_CONNECT_TIMEOUT = 10
 # Post-connect pause before issuing GATT commands (proxy backend needs time to
 # finish processing the GATT service table after establish_connection returns).
 BLE_POST_CONNECT_DELAY = 2.0
-# Time to wait for notifications after sending a command
-BLE_NOTIFICATION_WAIT = 3
+# Time to wait for the first session notification after sending a query command.
+# Must be long enough for the full *B# stream to arrive via an ESPHome BLE proxy:
+# observed rate ~437 B/s → 32 sessions × 42 B = 1 344 B ≈ 3.1 s; 60 sessions ≈ 5.8 s.
+# 8 s gives comfortable headroom for large session counts and slow proxy setups.
+BLE_NOTIFICATION_WAIT = 8
 # Extra wait after receiving a session, allowing the device time to push
 # enrichment notifications (0000 score, 2604 zone pressures).  These are
 # unsolicited pushes the device sends shortly after the 0307 session response.

--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -561,9 +561,9 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         all_sessions: list[dict[str, Any]] = []
         seen_ts: set[int] = set()
         session_received = asyncio.Event()
-        handler = self._make_notification_handler(collected, all_sessions, seen_ts, session_received)
+        handler, flush_pending = self._make_notification_handler(collected, all_sessions, seen_ts, session_received)
 
-        await self._run_ble_queries(client, collected, all_sessions, session_received, handler)
+        await self._run_ble_queries(client, collected, all_sessions, session_received, handler, flush_pending)
         self._finalize_sessions(collected, all_sessions)
         return all_sessions
 
@@ -573,13 +573,17 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         all_sessions: list[dict[str, Any]],
         seen_ts: set[int],
         session_received: asyncio.Event,
-    ) -> Callable[[Any, bytearray], None]:
-        """Return a BLE notification callback that accumulates session data.
+    ) -> tuple[Callable[[Any, bytearray], None], Callable[[], None]]:
+        """Return a (handler, flush_pending) pair for BLE notification processing.
 
-        The returned handler parses each notification, applies the "newer
-        timestamp wins" policy to prevent a stale 5a00 push from overwriting
-        a more-recent 0307 timestamp, merges fields into *collected*, and
-        appends new sessions to *all_sessions*.
+        *handler* is the BLE notification callback that accumulates session data.
+        It parses each notification, applies the "newer timestamp wins" policy to
+        prevent a stale 5a00 push from overwriting a more-recent 0307 timestamp,
+        merges fields into *collected*, and appends new sessions to *all_sessions*.
+
+        *flush_pending* flushes any complete 42-byte records already accumulated
+        in the *B# reassembly buffer.  Call it after the session-wait timeout to
+        recover records that arrived before the BLE connection is torn down.
 
         Multi-packet reassembly (*B# format):
         OCLEANY3 sends session records split across multiple BLE packets: a
@@ -690,7 +694,26 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
 
             _accept(parsed)
 
-        return handler
+        def flush_pending() -> None:
+            """Flush any complete 42-byte records buffered so far.
+
+            Called after the BLE session-wait timeout to recover records that
+            arrived before the connection is torn down but before the full
+            expected byte count was reached (e.g. slow ESPHome BLE proxy).
+            """
+            if _t1["in_progress"] and _t1["buf"]:
+                available = len(_t1["buf"])
+                complete = (available // T1_C3352G_RECORD_SIZE) * T1_C3352G_RECORD_SIZE
+                _log.debug(
+                    "*B# partial flush: %d/%d bytes, flushing %d complete record(s)",
+                    available,
+                    _t1["expected"],
+                    available // T1_C3352G_RECORD_SIZE,
+                )
+                _t1["expected"] = complete  # limit flush to complete records only
+                _flush_t1_buffer()
+
+        return handler, flush_pending
 
     async def _run_ble_queries(
         self,
@@ -699,6 +722,7 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         all_sessions: list[dict[str, Any]],
         session_received: asyncio.Event,
         handler: Callable[[Any, bytearray], None],
+        flush_pending: Callable[[], None],
     ) -> None:
         """Execute the full GATT operation sequence for one poll.
 
@@ -718,6 +742,9 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         subscribed = await self._subscribe_notifications(client, handler)
         await self._subscribe_battery_notifications(client, collected)
         await self._send_query_commands(client, session_received)
+        # If the session-wait timed out while a *B# stream was mid-flight (e.g.
+        # slow ESPHome proxy), flush whatever complete records arrived so far.
+        flush_pending()
         # Fallback for devices (e.g. OCLEANA1) where READ_NOTIFY_CHAR_UUID has no
         # CCCD and cannot be subscribed; poll the characteristic directly instead.
         if READ_NOTIFY_CHAR_UUID not in subscribed:

--- a/custom_components/oclean_ble/protocol.py
+++ b/custom_components/oclean_ble/protocol.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 
 from .const import (
     CHANGE_INFO_UUID,
-    CMD_QUERY_EXTENDED_DATA_T1,
     CMD_QUERY_RUNNING_DATA,
     CMD_QUERY_RUNNING_DATA_T1,
     CMD_QUERY_STATUS,
@@ -66,7 +65,6 @@ TYPE1 = DeviceProtocol(
     query_commands=(
         (WRITE_CHAR_UUID, CMD_QUERY_STATUS),
         (SEND_BRUSH_CMD_UUID, CMD_QUERY_RUNNING_DATA_T1),
-        (SEND_BRUSH_CMD_UUID, CMD_QUERY_EXTENDED_DATA_T1),
     ),
     supports_pagination=False,
 )
@@ -94,7 +92,6 @@ UNKNOWN = DeviceProtocol(
         (WRITE_CHAR_UUID, CMD_QUERY_STATUS),
         (WRITE_CHAR_UUID, CMD_QUERY_RUNNING_DATA),
         (SEND_BRUSH_CMD_UUID, CMD_QUERY_RUNNING_DATA_T1),
-        (SEND_BRUSH_CMD_UUID, CMD_QUERY_EXTENDED_DATA_T1),
     ),
     supports_pagination=True,  # safe: pagination stops when no new sessions arrive
 )


### PR DESCRIPTION
Three changes together fix an issue where OCLEANY3M (Oclean X) devices fail to import any sessions when connected via an ESPHome BLE proxy:

1. Remove CMD_QUERY_EXTENDED_DATA_T1 (0314) from TYPE1 and UNKNOWN protocol profiles. CMD 0314 (readRunningState) is only implemented by C3376s / C3381u0 handler devices (0005/0006/000D/000C/0010). Sending it to C3385w0 devices (OCLEANY3M, OCLEANY3) while the *B# stream is in progress interrupts the transfer and causes it to stall at ~1 053– 1 313 of the expected bytes.

2. Increase BLE_NOTIFICATION_WAIT from 3 s to 8 s. The *B# stream for 32 sessions (32 × 42 = 1 344 bytes) takes ~3.1 s at the observed proxy throughput of ~437 B/s; 8 s provides headroom for up to ~60 sessions and slower setups.

3. Add flush_pending() partial-buffer flush as a safety net. If the session-wait timeout fires before the full *B# buffer is received, flush_pending() extracts all complete 42-byte records already in the buffer instead of discarding them. _make_notification_handler now returns a (handler, flush_pending) tuple; _run_ble_queries calls flush_pending() immediately after _send_query_commands returns.

Closes #60