### PR TITLE
feat: parse gestureCode, gestureArray, powerArray and pressureRatio f…

### DIFF
--- a/custom_components/oclean_ble/const.py
+++ b/custom_components/oclean_ble/const.py
@@ -121,6 +121,10 @@ DATA_SW_VERSION = "sw_version"  # Software Revision from BLE DIS (e.g. "1.0.0.20
 DATA_LAST_BRUSH_AREAS = "last_brush_areas"  # dict: zone_name → pressure (0-255)
 DATA_LAST_BRUSH_PNUM = "last_brush_pnum"  # int (brush-scheme ID; see SCHEME_NAMES below)
 DATA_IS_BRUSHING = "is_brushing"  # bool: True while brushing (from 0303 byte 0 bit 0)
+DATA_LAST_BRUSH_GESTURE_CODE = "last_brush_gesture_code"  # int 0-255 (APK: byte 14)
+DATA_LAST_BRUSH_PRESSURE_RATIO = "last_brush_pressure_ratio"  # list[int] len=5 (bytes 11-15)
+DATA_LAST_BRUSH_GESTURE_ARRAY = "last_brush_gesture_array"  # list[int] len=13 (bytes 18-30)
+DATA_LAST_BRUSH_POWER_ARRAY = "last_brush_power_array"  # list[int] len=12, each 0-3 (nibbles from bytes 30-32)
 
 # Tooth area zone names in BrushAreaType enum order (value 1 → index 0 … value 8 → index 7)
 # Source: com/ocleanble/lib/device/BrushAreaType.java

--- a/custom_components/oclean_ble/models.py
+++ b/custom_components/oclean_ble/models.py
@@ -27,6 +27,10 @@ class OcleanDeviceData:
     model_id: str | None = None
     hw_revision: str | None = None
     sw_version: str | None = None
+    last_brush_gesture_code: int | None = None
+    last_brush_pressure_ratio: list[int] | None = None
+    last_brush_gesture_array: list[int] | None = None
+    last_brush_power_array: list[int] | None = None
 
     # ------------------------------------------------------------------
     # Convenience helpers
@@ -58,4 +62,8 @@ class OcleanDeviceData:
             model_id=data.get("model_id"),
             hw_revision=data.get("hw_revision"),
             sw_version=data.get("sw_version"),
+            last_brush_gesture_code=data.get("last_brush_gesture_code"),
+            last_brush_pressure_ratio=data.get("last_brush_pressure_ratio"),
+            last_brush_gesture_array=data.get("last_brush_gesture_array"),
+            last_brush_power_array=data.get("last_brush_power_array"),
         )

--- a/custom_components/oclean_ble/parser.py
+++ b/custom_components/oclean_ble/parser.py
@@ -16,8 +16,12 @@ from .const import (
     DATA_IS_BRUSHING,
     DATA_LAST_BRUSH_AREAS,
     DATA_LAST_BRUSH_DURATION,
+    DATA_LAST_BRUSH_GESTURE_ARRAY,
+    DATA_LAST_BRUSH_GESTURE_CODE,
     DATA_LAST_BRUSH_PNUM,
+    DATA_LAST_BRUSH_POWER_ARRAY,
     DATA_LAST_BRUSH_PRESSURE,
+    DATA_LAST_BRUSH_PRESSURE_RATIO,
     DATA_LAST_BRUSH_SCORE,
     DATA_LAST_BRUSH_TIME,
     RESP_BRUSH_AREAS_T1,
@@ -54,6 +58,15 @@ _EXT_MIN_SIZE = 32  # 0308 extended format (AbstractC0002b.m37y)
 def _parse_signed_byte(value: int) -> int:
     """Interpret a single byte as a signed int8 (-128..127)."""
     return value if value < 128 else value - 256
+
+
+def _extract_nibbles(byte_val: int) -> list[int]:
+    """Extract 4 × 2-bit values from one byte (APK: a.b.a / m13a).
+
+    Index 0 = MSBits 7-6, index 3 = LSBits 1-0.  Each value is 0-3.
+    Used to decode powerArray from bytes 30-32 of 42-byte 0307 records.
+    """
+    return [(byte_val >> (6 - 2 * i)) & 0x3 for i in range(4)]
 
 
 def _build_utc_timestamp(device_dt: datetime.datetime, tz_offset_quarters: int) -> int:
@@ -353,12 +366,23 @@ def _parse_m18f_record(record: bytes) -> dict[str, Any]:
             result[DATA_LAST_BRUSH_AREAS] = area_dict
             result[DATA_LAST_BRUSH_PRESSURE] = avg_pressure
 
+        # gestureCode / pressureRatio / gestureArray / powerArray (APK: C3385w0_fallback)
+        # pressureCode = m14b(bytes 11-15); formula TBD – raw inputs stored as pressureRatio.
+        result[DATA_LAST_BRUSH_GESTURE_CODE] = int(record[14])
+        result[DATA_LAST_BRUSH_PRESSURE_RATIO] = list(record[11:16])
+        result[DATA_LAST_BRUSH_GESTURE_ARRAY] = list(record[18:31])  # bytes 18-30 inclusive
+        result[DATA_LAST_BRUSH_POWER_ARRAY] = (
+            _extract_nibbles(record[30]) + _extract_nibbles(record[31]) + _extract_nibbles(record[32])
+        )
+        _LOGGER.debug("Oclean 0307 m18f record point=%d (raw byte 34, APK: not used)", record[34])
+
         _LOGGER.debug(
-            "Oclean 0307 m18f parsed: ts=%d pNum=%d duration=%s score=%s (raw: %s)",
+            "Oclean 0307 m18f parsed: ts=%d pNum=%d duration=%s score=%s gestureCode=%d (raw: %s)",
             timestamp_s,
             result[DATA_LAST_BRUSH_PNUM],
             result.get(DATA_LAST_BRUSH_DURATION, "n/a"),
             result.get(DATA_LAST_BRUSH_SCORE, "n/a"),
+            result[DATA_LAST_BRUSH_GESTURE_CODE],
             record[:_T1_FULL_RECORD_SIZE].hex(),
         )
         return result
@@ -454,12 +478,22 @@ def parse_t1_c3352g_record(record: bytes) -> dict[str, Any]:
             result[DATA_LAST_BRUSH_AREAS] = area_dict
             result[DATA_LAST_BRUSH_PRESSURE] = avg_pressure
 
+        # gestureCode / pressureRatio / gestureArray / powerArray (APK: C3385w0_fallback)
+        result[DATA_LAST_BRUSH_GESTURE_CODE] = int(record[14])
+        result[DATA_LAST_BRUSH_PRESSURE_RATIO] = list(record[11:16])
+        result[DATA_LAST_BRUSH_GESTURE_ARRAY] = list(record[18:31])
+        result[DATA_LAST_BRUSH_POWER_ARRAY] = (
+            _extract_nibbles(record[30]) + _extract_nibbles(record[31]) + _extract_nibbles(record[32])
+        )
+        _LOGGER.debug("Oclean C3352g record point=%d (raw byte 34, APK: not used)", record[34])
+
         _LOGGER.debug(
-            "Oclean C3352g record parsed: ts=%d pNum=%d duration=%s score=%s (raw: %s)",
+            "Oclean C3352g record parsed: ts=%d pNum=%d duration=%s score=%s gestureCode=%d (raw: %s)",
             timestamp_s,
             result[DATA_LAST_BRUSH_PNUM],
             result.get(DATA_LAST_BRUSH_DURATION, "n/a"),
             result.get(DATA_LAST_BRUSH_SCORE, "n/a"),
+            result[DATA_LAST_BRUSH_GESTURE_CODE],
             record[:T1_C3352G_RECORD_SIZE].hex(),
         )
         return result
@@ -535,11 +569,21 @@ def parse_y3p_stream_record(record: bytes) -> dict[str, Any]:
         if 0 < score <= 100:
             result[DATA_LAST_BRUSH_SCORE] = score
 
+        # gestureCode / pressureRatio / gestureArray / powerArray (APK: C3385w0_fallback)
+        result[DATA_LAST_BRUSH_GESTURE_CODE] = int(record[14])
+        result[DATA_LAST_BRUSH_PRESSURE_RATIO] = list(record[11:16])
+        result[DATA_LAST_BRUSH_GESTURE_ARRAY] = list(record[18:31])
+        result[DATA_LAST_BRUSH_POWER_ARRAY] = (
+            _extract_nibbles(record[30]) + _extract_nibbles(record[31]) + _extract_nibbles(record[32])
+        )
+        _LOGGER.debug("Oclean Y3P stream record point=%d (raw byte 34, APK: not used)", record[34])
+
         _LOGGER.debug(
-            "Oclean Y3P stream record: ts=%d duration=%s score=%s (raw: %s)",
+            "Oclean Y3P stream record: ts=%d duration=%s score=%s gestureCode=%d (raw: %s)",
             timestamp_s,
             result.get(DATA_LAST_BRUSH_DURATION, "n/a"),
             result.get(DATA_LAST_BRUSH_SCORE, "n/a"),
+            result[DATA_LAST_BRUSH_GESTURE_CODE],
             record[:T1_C3352G_RECORD_SIZE].hex(),
         )
         return result

--- a/custom_components/oclean_ble/sensor.py
+++ b/custom_components/oclean_ble/sensor.py
@@ -24,7 +24,10 @@ from .const import (
     DATA_HW_REVISION,
     DATA_LAST_BRUSH_AREAS,
     DATA_LAST_BRUSH_DURATION,
+    DATA_LAST_BRUSH_GESTURE_ARRAY,
+    DATA_LAST_BRUSH_GESTURE_CODE,
     DATA_LAST_BRUSH_PNUM,
+    DATA_LAST_BRUSH_POWER_ARRAY,
     DATA_LAST_BRUSH_PRESSURE,
     DATA_LAST_BRUSH_SCORE,
     DATA_LAST_BRUSH_TIME,
@@ -143,6 +146,9 @@ async def async_setup_entry(
     entities.append(OcleanBrushAreasSensor(coordinator, mac, device_name))
     entities.append(OcleanSchemeSensor(coordinator, mac, device_name))
     entities.extend(OcleanToothAreaSensor(coordinator, mac, device_name, zone_name) for zone_name in TOOTH_AREA_NAMES)
+    entities.append(OcleanGestureCodeSensor(coordinator, mac, device_name))
+    entities.append(OcleanGestureArraySensor(coordinator, mac, device_name))
+    entities.append(OcleanPowerArraySensor(coordinator, mac, device_name))
     async_add_entities(entities)
 
 
@@ -307,3 +313,111 @@ class OcleanToothAreaSensor(OcleanEntity, SensorEntity):
     def available(self) -> bool:
         """Return True if coordinator is available or we have stale area data."""
         return self._session_field_available(_get_areas(self.coordinator.data))
+
+
+class OcleanGestureCodeSensor(OcleanEntity, SensorEntity):
+    """Sensor for the gestureCode byte from 42-byte 0307 session records.
+
+    gestureCode = byte 14 of the 42-byte record (APK: iBytesToIntBe13 / m14b component 3).
+    Raw value 0-255; exact semantics TBD pending empirical analysis.
+    """
+
+    _attr_name = "Last Brush Gesture Code"
+    _attr_icon = "mdi:gesture"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: OcleanCoordinator, mac: str, device_name: str) -> None:
+        super().__init__(coordinator, mac, device_name, DATA_LAST_BRUSH_GESTURE_CODE)
+
+    @property
+    def native_value(self) -> int | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get(DATA_LAST_BRUSH_GESTURE_CODE)
+
+    @property
+    def available(self) -> bool:
+        return self._session_field_available(self.native_value)
+
+
+class OcleanGestureArraySensor(OcleanEntity, SensorEntity):
+    """Sensor exposing the full 13-element gestureArray from 42-byte 0307 records.
+
+    gestureArray = bytes 18-30 of the 42-byte record (APK: C3385w0_fallback).
+    State: number of non-zero elements (0-13).
+    Attributes: gesture_0 … gesture_12 with the raw per-zone motion values.
+    Note: elements [3:11] (bytes 21-28) overlap with the area-pressure sensor.
+    """
+
+    _attr_name = "Last Brush Gesture Array"
+    _attr_icon = "mdi:chart-bar"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: OcleanCoordinator, mac: str, device_name: str) -> None:
+        super().__init__(coordinator, mac, device_name, DATA_LAST_BRUSH_GESTURE_ARRAY)
+
+    def _get_array(self) -> list[int] | None:
+        if self.coordinator.data is None:
+            return None
+        val = self.coordinator.data.get(DATA_LAST_BRUSH_GESTURE_ARRAY)
+        return val if isinstance(val, list) else None
+
+    @property
+    def native_value(self) -> int | None:
+        arr = self._get_array()
+        return sum(1 for v in arr if v > 0) if arr is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        arr = self._get_array()
+        if arr is None:
+            return None
+        return {f"gesture_{i}": v for i, v in enumerate(arr)}
+
+    @property
+    def available(self) -> bool:
+        return self._session_field_available(self._get_array())
+
+
+class OcleanPowerArraySensor(OcleanEntity, SensorEntity):
+    """Sensor exposing the 12-element powerArray from 42-byte 0307 records.
+
+    powerArray = 12 × 2-bit nibbles extracted from bytes 30-32 (APK: a.b.a / m13a).
+    Each value is 0-3 (power intensity level for one zone).
+    State: average power level (float 0.0-3.0).
+    Attributes: power_0 … power_11 with individual nibble values.
+    """
+
+    _attr_name = "Last Brush Power Array"
+    _attr_icon = "mdi:lightning-bolt"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: OcleanCoordinator, mac: str, device_name: str) -> None:
+        super().__init__(coordinator, mac, device_name, DATA_LAST_BRUSH_POWER_ARRAY)
+
+    def _get_array(self) -> list[int] | None:
+        if self.coordinator.data is None:
+            return None
+        val = self.coordinator.data.get(DATA_LAST_BRUSH_POWER_ARRAY)
+        return val if isinstance(val, list) else None
+
+    @property
+    def native_value(self) -> float | None:
+        arr = self._get_array()
+        if arr is None or len(arr) == 0:
+            return None
+        return round(sum(arr) / len(arr), 2)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        arr = self._get_array()
+        if arr is None:
+            return None
+        return {f"power_{i}": v for i, v in enumerate(arr)}
+
+    @property
+    def available(self) -> bool:
+        return self._session_field_available(self._get_array())

--- a/custom_components/oclean_ble/translations/de.json
+++ b/custom_components/oclean_ble/translations/de.json
@@ -76,6 +76,15 @@
       },
       "hw_revision": {
         "name": "Hardware-Revision"
+      },
+      "last_brush_gesture_code": {
+        "name": "Letzter Gestencode"
+      },
+      "last_brush_gesture_array": {
+        "name": "Letztes Gestenarray"
+      },
+      "last_brush_power_array": {
+        "name": "Letztes Kraftarray"
       }
     }
   },

--- a/custom_components/oclean_ble/translations/en.json
+++ b/custom_components/oclean_ble/translations/en.json
@@ -76,6 +76,15 @@
       },
       "hw_revision": {
         "name": "Hardware Revision"
+      },
+      "last_brush_gesture_code": {
+        "name": "Last Brush Gesture Code"
+      },
+      "last_brush_gesture_array": {
+        "name": "Last Brush Gesture Array"
+      },
+      "last_brush_power_array": {
+        "name": "Last Brush Power Array"
       }
     }
   },

--- a/custom_components/oclean_ble/translations/es.json
+++ b/custom_components/oclean_ble/translations/es.json
@@ -76,6 +76,15 @@
       },
       "hw_revision": {
         "name": "Revisión de hardware"
+      },
+      "last_brush_gesture_code": {
+        "name": "Código de gesto del último cepillado"
+      },
+      "last_brush_gesture_array": {
+        "name": "Array de gestos del último cepillado"
+      },
+      "last_brush_power_array": {
+        "name": "Array de potencia del último cepillado"
       }
     }
   },


### PR DESCRIPTION
…rom 42-byte 0307 records (#65)

Byte layout source: C3385w0_fallback.java + AbstractC0002b.m18f (APK)

- Add _extract_nibbles() helper (APK: a.b.a / m13a, 4 × 2-bit per byte)
- Extract gestureCode (byte 14), pressureRatio (bytes 11-15), gestureArray (bytes 18-30, 13 values), powerArray (nibbles from bytes 30-32, 12 values) in _parse_m18f_record(), parse_t1_c3352g_record(), parse_y3p_stream_record()
- Log point (byte 34) at DEBUG level (APK: not used)
- Add DATA_LAST_BRUSH_GESTURE_CODE/PRESSURE_RATIO/GESTURE_ARRAY/POWER_ARRAY constants
- Add four new optional fields to OcleanDeviceData
- Add OcleanGestureCodeSensor, OcleanGestureArraySensor, OcleanPowerArraySensor (all EntityCategory.DIAGNOSTIC)
- Update translations (en/de/es)

pressureCode = m14b(bytes 11-15); m14b formula TBD – raw inputs stored as pressureRatio for empirical research.