### PR TITLE
feat: add Over-Pressure Alert switch

### DIFF
--- a/custom_components/oclean_ble/const.py
+++ b/custom_components/oclean_ble/const.py
@@ -123,6 +123,8 @@ CMD_SET_BRUSH_SCHEME = bytes.fromhex("0206")  # packet 1 header
 CMD_SET_BRUSH_SCHEME_CONT = bytes.fromhex("020B")  # packet 2 header (MTU split only)
 # Area reminder command (mo5298S, OcleanBleManager.setAreaRemind)
 CMD_AREA_REMIND = bytes.fromhex("020D")  # + 0x01 (on) / 0x00 (off)
+# Over-pressure alert command (C3376s.G0() in APK, same byte pattern as area_remind)
+CMD_OVER_PRESSURE = bytes.fromhex("0212")  # + 0x01 (on) / 0x00 (off)
 # Brush head max lifetime command (mo5345x, OcleanBleManager.setRunningHeadMaxTime)
 CMD_BRUSH_HEAD_MAX_DAYS = bytes.fromhex("0217")  # + 2-byte big-endian uint16 (days)
 

--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -37,6 +37,7 @@ from .const import (
     CMD_CALIBRATE_TIME_PREFIX,
     CMD_CALIBRATE_TIME_T1_PREFIX,
     CMD_CLEAR_BRUSH_HEAD,
+    CMD_OVER_PRESSURE,
     CMD_QUERY_RUNNING_DATA_NEXT,
     CMD_SET_BRUSH_SCHEME_CONT,
     DATA_BATTERY,
@@ -306,6 +307,7 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
 
         # User-controlled device settings (write-only; state persisted locally).
         self._area_remind: bool | None = None
+        self._over_pressure: bool | None = None
         self._brush_head_max_days: int | None = None
         # Software brush-head session counter: counts new sessions since the last
         # brush-head reset when the device does not expose a hardware counter via 0302.
@@ -463,6 +465,11 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         return self._area_remind
 
     @property
+    def over_pressure(self) -> bool | None:
+        """Return the last-written over-pressure alert state, or None if never set."""
+        return self._over_pressure
+
+    @property
     def brush_head_max_days(self) -> int | None:
         """Return the last-written brush-head max-lifetime in days, or None if never set."""
         return self._brush_head_max_days
@@ -489,6 +496,30 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
             if client.is_connected:
                 await client.disconnect()
         self._area_remind = enabled
+        await self._save_store()
+
+    async def async_set_over_pressure(self, enabled: bool) -> None:
+        """Connect and write CMD_OVER_PRESSURE (0212) to the device.
+
+        Called by the Over-Pressure Alert switch entity.  State is persisted so
+        the switch shows the correct value after HA restarts.
+        """
+        ble_device = self._resolve_ble_device()
+        client = await establish_connection(
+            BleakClient,
+            ble_device,
+            self._device_name,
+            max_attempts=3,
+        )
+        cmd = CMD_OVER_PRESSURE + bytes([0x01 if enabled else 0x00])
+        try:
+            await asyncio.sleep(BLE_POST_CONNECT_DELAY)
+            await self._write_standalone(client, cmd)
+            self._log.info("over pressure alert set to %s", enabled)
+        finally:
+            if client.is_connected:
+                await client.disconnect()
+        self._over_pressure = enabled
         await self._save_store()
 
     async def async_set_brush_head_max_days(self, days: int) -> None:
@@ -651,6 +682,7 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         if stored:
             self._last_session_ts = stored.get("last_session_ts", 0)
             self._area_remind = stored.get("area_remind")
+            self._over_pressure = stored.get("over_pressure")
             self._brush_head_max_days = stored.get("brush_head_max_days")
             self._brush_head_sw_count = stored.get("brush_head_sw_count", 0)
             self._active_scheme_pnum = stored.get("active_scheme_pnum")
@@ -672,6 +704,7 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
             {
                 "last_session_ts": self._last_session_ts,
                 "area_remind": self._area_remind,
+                "over_pressure": self._over_pressure,
                 "brush_head_max_days": self._brush_head_max_days,
                 "brush_head_sw_count": self._brush_head_sw_count,
                 "active_scheme_pnum": self._active_scheme_pnum,

--- a/custom_components/oclean_ble/parser.py
+++ b/custom_components/oclean_ble/parser.py
@@ -1314,6 +1314,7 @@ _JSON_KEY_MAP: tuple[tuple[str, tuple[str, ...], bool], ...] = (
     (DATA_LAST_BRUSH_DURATION, ("duration", "brushDuration", "brush_duration", "time"), True),
     (DATA_LAST_BRUSH_PRESSURE, ("pressure", "avgPressure", "avg_pressure"), True),
     (DATA_LAST_BRUSH_TIME, ("timestamp", "endTime", "end_time", "brushTime"), False),
+    (DATA_BRUSH_MODE, ("modeNum", "mode_num", "brushMode"), True),
 )
 
 

--- a/custom_components/oclean_ble/switch.py
+++ b/custom_components/oclean_ble/switch.py
@@ -17,6 +17,11 @@ SWITCH_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
         name="Area Reminder",
         icon="mdi:tooth-outline",
     ),
+    SwitchEntityDescription(
+        key="over_pressure",
+        name="Over-Pressure Alert",
+        icon="mdi:gauge-full",
+    ),
 )
 
 
@@ -56,12 +61,18 @@ class OcleanSwitch(OcleanEntity, SwitchEntity):
     def is_on(self) -> bool | None:
         if self.entity_description.key == "area_remind":
             return self.coordinator.area_remind
+        if self.entity_description.key == "over_pressure":
+            return self.coordinator.over_pressure
         return None
 
     async def async_turn_on(self, **kwargs) -> None:
         if self.entity_description.key == "area_remind":
             await self.coordinator.async_set_area_remind(True)
+        elif self.entity_description.key == "over_pressure":
+            await self.coordinator.async_set_over_pressure(True)
 
     async def async_turn_off(self, **kwargs) -> None:
         if self.entity_description.key == "area_remind":
             await self.coordinator.async_set_area_remind(False)
+        elif self.entity_description.key == "over_pressure":
+            await self.coordinator.async_set_over_pressure(False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,6 +306,21 @@ def _install_ha_stubs() -> None:
     bs.BinarySensorEntityDescription = BinarySensorEntityDescription
     bs.BinarySensorEntity = BinarySensorEntity
 
+    # ---- homeassistant.components.switch ----
+    sw = _stub("homeassistant.components.switch")
+
+    class SwitchEntityDescription:
+        def __init__(self, *, key, name="", icon=None, **kwargs):
+            self.key = key
+            self.name = name
+            self.icon = icon
+
+    class SwitchEntity:
+        pass
+
+    sw.SwitchEntityDescription = SwitchEntityDescription
+    sw.SwitchEntity = SwitchEntity
+
     # ---- bleak (stub if not installed) ----
     if "bleak" not in sys.modules or not hasattr(sys.modules["bleak"], "BleakError"):
         bleak = _stub("bleak")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,151 @@
+"""Tests for switch.py – OcleanSwitch entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# conftest.py stubs HA + bleak before these imports
+from custom_components.oclean_ble.switch import SWITCH_DESCRIPTIONS, OcleanSwitch, async_setup_entry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(area_remind=None, over_pressure=None):
+    coord = MagicMock()
+    coord.area_remind = area_remind
+    coord.over_pressure = over_pressure
+    coord.async_set_area_remind = AsyncMock()
+    coord.async_set_over_pressure = AsyncMock()
+    return coord
+
+
+def _make_switch(key: str, area_remind=None, over_pressure=None):
+    coord = _make_coordinator(area_remind=area_remind, over_pressure=over_pressure)
+    desc = next(d for d in SWITCH_DESCRIPTIONS if d.key == key)
+    return OcleanSwitch(coord, desc, "AA:BB:CC:DD:EE:FF", "Oclean X")
+
+
+# ---------------------------------------------------------------------------
+# SWITCH_DESCRIPTIONS
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchDescriptions:
+    def test_area_remind_present(self):
+        keys = [d.key for d in SWITCH_DESCRIPTIONS]
+        assert "area_remind" in keys
+
+    def test_over_pressure_present(self):
+        keys = [d.key for d in SWITCH_DESCRIPTIONS]
+        assert "over_pressure" in keys
+
+
+# ---------------------------------------------------------------------------
+# is_on – area_remind
+# ---------------------------------------------------------------------------
+
+
+class TestIsOnAreaRemind:
+    def test_returns_none_when_not_set(self):
+        sw = _make_switch("area_remind", area_remind=None)
+        assert sw.is_on is None
+
+    def test_returns_true(self):
+        sw = _make_switch("area_remind", area_remind=True)
+        assert sw.is_on is True
+
+    def test_returns_false(self):
+        sw = _make_switch("area_remind", area_remind=False)
+        assert sw.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# is_on – over_pressure
+# ---------------------------------------------------------------------------
+
+
+class TestIsOnOverPressure:
+    def test_returns_none_when_not_set(self):
+        sw = _make_switch("over_pressure", over_pressure=None)
+        assert sw.is_on is None
+
+    def test_returns_true(self):
+        sw = _make_switch("over_pressure", over_pressure=True)
+        assert sw.is_on is True
+
+    def test_returns_false(self):
+        sw = _make_switch("over_pressure", over_pressure=False)
+        assert sw.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# async_turn_on / async_turn_off – area_remind
+# ---------------------------------------------------------------------------
+
+
+class TestTurnAreaRemind:
+    @pytest.mark.asyncio
+    async def test_turn_on_calls_set_area_remind_true(self):
+        sw = _make_switch("area_remind")
+        await sw.async_turn_on()
+        sw.coordinator.async_set_area_remind.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_turn_off_calls_set_area_remind_false(self):
+        sw = _make_switch("area_remind")
+        await sw.async_turn_off()
+        sw.coordinator.async_set_area_remind.assert_awaited_once_with(False)
+
+
+# ---------------------------------------------------------------------------
+# async_turn_on / async_turn_off – over_pressure
+# ---------------------------------------------------------------------------
+
+
+class TestTurnOverPressure:
+    @pytest.mark.asyncio
+    async def test_turn_on_calls_set_over_pressure_true(self):
+        sw = _make_switch("over_pressure")
+        await sw.async_turn_on()
+        sw.coordinator.async_set_over_pressure.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_turn_off_calls_set_over_pressure_false(self):
+        sw = _make_switch("over_pressure")
+        await sw.async_turn_off()
+        sw.coordinator.async_set_over_pressure.assert_awaited_once_with(False)
+
+
+# ---------------------------------------------------------------------------
+# async_setup_entry
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSetupEntry:
+    @pytest.mark.asyncio
+    async def test_registers_both_switches(self):
+        """async_setup_entry must create one entity per SWITCH_DESCRIPTIONS entry."""
+        from custom_components.oclean_ble.const import CONF_DEVICE_NAME, CONF_MAC_ADDRESS, DOMAIN
+
+        hass = MagicMock()
+        hass.data = {}
+        coord = _make_coordinator()
+        hass.data[DOMAIN] = {"entry_id_123": coord}
+
+        entry = MagicMock()
+        entry.entry_id = "entry_id_123"
+        entry.data = {CONF_MAC_ADDRESS: "AA:BB:CC:DD:EE:FF", CONF_DEVICE_NAME: "Oclean"}
+
+        added = []
+        async_add = MagicMock(side_effect=added.extend)
+
+        await async_setup_entry(hass, entry, async_add)
+
+        assert len(added) == len(SWITCH_DESCRIPTIONS)
+        keys = {e.entity_description.key for e in added}
+        assert "area_remind" in keys
+        assert "over_pressure" in keys


### PR DESCRIPTION
Closes #75

## Summary

- New `_over_pressure` switch entity (icon: `mdi:gauge-full`)
- BLE command `0x0212` confirmed from APK source `C3376s.G0()`
- State persisted across HA restarts; `_attr_assumed_state = True`
- Also maps `modeNum` in `_JSON_KEY_MAP` for the Mode sensor JSON fallback

## Test plan

- [ ] 13 unit tests in `tests/test_switch.py` (all pass locally)
- [ ] Real-device test: toggle switch in HA UI → verify device LED/haptic confirms the alert setting change

🤖 Generated with [Claude Code](https://claude.com/claude-code)