### PR TITLE
feat: retry OCLEANV1a receive-brush probe after inline-only session

### DIFF
--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -1230,6 +1230,34 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         has_session_data = bool(all_sessions) or DATA_LAST_BRUSH_TIME in collected
         if has_session_data:
             await asyncio.sleep(BLE_ENRICHMENT_WAIT)
+
+            model_id = str(collected.get(DATA_MODEL_ID) or self._last_raw.get(DATA_MODEL_ID) or "")
+            new_ts = int(collected.get(DATA_LAST_BRUSH_TIME, 0) or 0)
+            prev_ts = int(self._last_raw.get(DATA_LAST_BRUSH_TIME, 0) or 0)
+            has_core_inline_only = (
+                model_id == "OCLEANV1a"
+                and new_ts > prev_ts
+                and DATA_LAST_BRUSH_PNUM in collected
+                and DATA_LAST_BRUSH_DURATION in collected
+                and not any(key in collected for key in _ENRICHMENT_KEYS)
+            )
+
+            if has_core_inline_only:
+                self._log.debug(
+                    "OCLEANV1a new inline-only session detected after enrichment wait; "
+                    "retrying receive-brush probe for possible follow-up packets"
+                )
+                if RECEIVE_BRUSH_UUID in self._protocol.notify_chars:
+                    with contextlib.suppress(Exception):
+                        await self._poll_receive_brush_fallback(client, handler, session_received)
+                    await asyncio.sleep(BLE_ENRICHMENT_WAIT)
+
+                seen = [key for key in _ENRICHMENT_KEYS if key in collected]
+                self._log.debug(
+                    "OCLEANV1a enrichment retry complete; enrichment keys present: %s",
+                    seen or ["none"],
+                )
+
         await self._read_battery_and_unsubscribe(client, collected)
 
     def _finalize_sessions(


### PR DESCRIPTION
## Summary

Add a small OCLEANV1a-specific follow-up probe when a new session is detected but only inline 0307 core fields are present after the normal enrichment wait.

## Why

Real OCLEANV1a logs currently confirm reliable inline 0307 parsing for:

- timestamp
- pNum
- duration

However, under clean manual post-session testing, no follow-up enrichment packets (`2604`, `021f`, `0308`, `0000`) were observed, so score / areas / pressure remain unavailable.

## What this changes

- after the existing enrichment wait, detect new inline-only OCLEANV1a sessions
- retry `RECEIVE_BRUSH_UUID` fallback polling once more
- wait again briefly for any delayed follow-up packets
- log which enrichment keys, if any, became available

## What this does not do

- no parser remapping of unknown bytes
- no inferred score / areas / pressure
- no behavior changes for other models beyond the existing shared fallback path

## Validation

Tested on real OCLEANV1a hardware after installing this branch in Home Assistant via HACS.

Observed result:

- the new follow-up probe path is executed
- logs show `OCLEANV1a enrichment retry complete; enrichment keys present: ['none']`
- timestamp updates correctly
- duration updates correctly
- pNum updates correctly
- score / areas / pressure / coverage still remain unavailable

So this change improves observability and gives OCLEANV1a one more chance to expose delayed follow-up data, without changing confirmed parsing semantics.

Refs #81