### PR TITLE
Fix config entry setup aborting with CancelledError from BLE proxy

### DIFF
--- a/custom_components/oclean_ble/coordinator.py
+++ b/custom_components/oclean_ble/coordinator.py
@@ -475,6 +475,23 @@ class OcleanCoordinator(DataUpdateCoordinator[OcleanDeviceData]):
         try:
             raw = await self._poll_device()
             return OcleanDeviceData.from_dict(raw)
+        except asyncio.CancelledError as err:
+            # The ESPHome BLE-proxy connect path leaks a *spurious* CancelledError
+            # when a connection to a sleeping device times out (its internal
+            # disconnect-guard cancels an await). CancelledError is a
+            # BaseException, so the `except Exception` below never catches it and
+            # it would otherwise abort async_setup_entry ("config entry cancelled").
+            # A *genuine* task cancellation (HA shutdown / entry reload) sets
+            # current_task().cancelling() > 0 and MUST propagate – only translate
+            # the spurious proxy cancellation into a retryable UpdateFailed.
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                raise
+            self._log.debug("poll cancelled by BLE proxy (device likely asleep): %s", err)
+            self.last_poll_successful = False
+            if self._last_raw:
+                return OcleanDeviceData.from_dict(self._last_raw)
+            raise UpdateFailed(f"Oclean device not reachable (proxy cancelled): {err}") from err
         except Exception as err:
             # Catch all exceptions (BleakError, TimeoutError, IndexError from
             # habluetooth proxy backend, etc.) so HA can keep retrying rather


### PR DESCRIPTION
## Problem

Adding an Oclean device whose toothbrush is asleep at setup time fails with:

```
Setup of config entry '...' for oclean_ble integration cancelled
...
asyncio.exceptions.CancelledError
```

This is the same failure family as #9, but on the **connect** path rather than the `_paginate_sessions` write path that #9 fixed.

## Root cause

When a poll targets a sleeping device over an ESPHome Bluetooth proxy, `aioesphomeapi`'s internal disconnect-guard cancels an await after the connect timeout, and a bare `asyncio.CancelledError` leaks out of `establish_connection`.

`CancelledError` is a `BaseException`, **not** an `Exception`, so the existing `except Exception` in `_async_update_data` never catches it. It propagates out of `async_setup_entry`, and Home Assistant aborts the config entry ("Setup of config entry … cancelled").

## Fix

Catch `CancelledError` explicitly in `_async_update_data` and convert it into a retryable `UpdateFailed`, so the coordinator keeps retrying (or serves cached data) instead of killing setup.

A **genuine** task cancellation (HA shutdown / entry reload) has `current_task().cancelling() > 0` and is re-raised, so cooperative cancellation still works correctly. Only the spurious proxy-originated cancellation is swallowed.

This mirrors the `except BaseException  # must catch CancelledError (issue #9)` guard already present in `_paginate_sessions`.

## Testing

Verified on a live Home Assistant OS install (core-2026.6.4, Python 3.14.5) with real Oclean X and Oclean X Pro devices reached through an ESPHome BLE proxy. Before: config entries aborted with the traceback above. After: entries load cleanly and stay available while the device is asleep, then populate on the next successful poll.
